### PR TITLE
spark-operator-static 0.1.2

### DIFF
--- a/charts/spark-operator-static/Chart.yaml
+++ b/charts/spark-operator-static/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Spark Operator (static part)
 name: spark-operator-static
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 maintainers:
   - name: thorsteinnth
     email: thorsteinn.sigurdsson@netapp.com

--- a/charts/spark-operator-static/templates/spark-driver-rbac.yaml
+++ b/charts/spark-operator-static/templates/spark-driver-rbac.yaml
@@ -18,6 +18,12 @@ rules:
   - apiGroups: [ "" ] # "" indicates the core API group
     resources: [ "pods/log" ]
     verbs: [ "get" ]
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources: [ "services" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
While Spark is shutting down (after a kill), the driver was logging the following:

```
21/11/10 12:47:30 ERROR Utils: Uncaught exception in thread shutdown-hook-0
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/api/v1/namespaces/spark-apps/services?labelSelector=spark-app-selector%3Dspark-56a9998472f54cfd9a36bbfccbdaacf8. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services is forbidden: User "system:serviceaccount:spark-apps:spark-driver" cannot list resource "services" in API group "" in the namespace "spark-apps".
```

```
21/11/10 12:47:30 ERROR Utils: Uncaught exception in thread shutdown-hook-0
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://kubernetes.default.svc/api/v1/namespaces/spark-apps/persistentvolumeclaims?labelSelector=spark-app-selector%3Dspark-56a9998472f54cfd9a36bbfccbdaacf8. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. persistentvolumeclaims is forbidden: User "system:serviceaccount:spark-apps:spark-driver" cannot list resource "persistentvolumeclaims" in API group "" in the namespace "spark-apps".
```