### PR TITLE
bigdata-notebook-service v0.1.1

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.1
+appVersion: 0.1.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 maintainers:

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -30,7 +30,7 @@ ingress:
   secretNamespace: ""  # Overridden at deploy time
   secretName: ""  # Overridden at deploy time
 
-egBaseUrl: "notebooks"
+egBaseUrl: "/"
 egLogLevel: "DEBUG"
 
 # Has to be in sync with bigdata-notebook-service-storage chart

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-notebook-service
   pullPolicy: IfNotPresent
-  tag: 4ad39e50
+  tag: 53b9636c
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull


### PR DESCRIPTION
- bump image
- set egBaseUrl to "/" by default, instead of overriding it in the BigDataEnvironment definition