### PR TITLE
bigdata-notebook-service on-demand and restrict scale down

### DIFF
--- a/charts/bigdata-notebook-service-storage-server/Chart.yaml
+++ b/charts/bigdata-notebook-service-storage-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service-storage-server
 description: A Helm chart for the Spot Big Data Notebook Service Storage Server
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.8"
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service-storage-server/templates/notebook-service-storage-deployment.yaml
+++ b/charts/bigdata-notebook-service-storage-server/templates/notebook-service-storage-deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "bigdata-notebook-service-storage-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/bigdata-notebook-service-storage-server/values.yaml
+++ b/charts/bigdata-notebook-service-storage-server/values.yaml
@@ -38,10 +38,9 @@ tolerations: []
 
 affinity:
   nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 1
-      preference:
-        matchExpressions:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
         - key: spotinst.io/node-lifecycle
           operator: In
           values:

--- a/charts/bigdata-notebook-service-storage-server/values.yaml
+++ b/charts/bigdata-notebook-service-storage-server/values.yaml
@@ -14,6 +14,9 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
+podLabels:
+  spotinst.io/restrict-scale-down: "true"
+
 serviceAccount:
   create: false
   name: ""

--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/templates/deployment.yaml
+++ b/charts/bigdata-notebook-service/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "bigdata-notebook-service.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -66,4 +66,12 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: spotinst.io/node-lifecycle
+          operator: In
+          values:
+          - od

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -49,6 +49,9 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels:
+  spotinst.io/restrict-scale-down: "true"
+
 podSecurityContext:
   fsGroup: 1000
 


### PR DESCRIPTION
The bigdata-notebook-service and bigdata-notebook-service-storage-server should be run on OD instances, and not be scaled down during bin-packing operations