### PR TITLE
bigdata-spark-watcher v0.1.3

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.3
+appVersion: 0.1.3
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/templates/role.yaml
+++ b/charts/bigdata-spark-watcher/templates/role.yaml
@@ -36,6 +36,7 @@ rules:
   - list
   - watch
   - patch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.1.1-cec1390a
+  tag: 0.1.3-db2de814
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -55,10 +55,9 @@ tolerations: []
 
 affinity:
   nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 1
-      preference:
-        matchExpressions:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
         - key: spotinst.io/node-lifecycle
           operator: In
           values:


### PR DESCRIPTION
- bump to v0.1.3
- add permission to delete sparkapps - required for hammer kill
- require OD (will be required for our system components)