### PR TITLE
spark-operator v0.1.4

### DIFF
--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.3
+version: 0.1.4
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
@@ -1,30 +1,39 @@
 {{- if or .Values.rbac.create .Values.rbac.createClusterRole }}
 {{- /*
       Helm hook changes by OfAS:
-      Added:
-      - pre-upgrade
-        - RBAC should be created/updated during upgrade process
-      - post-upgrade
-        - When upgrading from an old release that does not manage RBAC via hooks - with only the pre-upgrade hook specified - the following happens:
-        - RBAC gets deleted, created, then deleted again
-        - Hacky solution: Also create it in the post-upgrade step.
-        - Since we have the before-hook-creation hook-delete-policy the object will be deleted and recreated if it already exists.
-
-      Discarded alternative:
       - Don't manage RBAC via helm hooks
       - Don't run the webhook init job via helm hook - therefore we don't need to create the RBAC in a hook either.
       - However, the webhook cleanup job is run by a helm hook - deleting webhook certs on deletion and upgrades.
-      - To make sure that the webhook init job runs on upgrades (even if the yaml was not changed), we set a short TTL-after-competion on the job.
-      - This makes it go away, and be re-run on upgrades.
-      - Discarded because the TTL controller was not enabled by default until k8s 1.21 (https://v1-20.docs.kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
+      - To make sure that the webhook init job runs on upgrades, all old webhook init jobs must have been deleted first.
+      - To accomplish this:
+        - The webhook cleanup job already deletes the init job - so it should go away in most cases before being run again
+        - We set a short TTL-after-competion on the job. This makes it go away, and allows a re-run on upgrades.
+          - However, the TTL controller was not enabled by default until k8s 1.21 (https://v1-20.docs.kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
+        - We also make sure (in bigdata-operator) that all webhook init jobs that may still be present are deleted before upgrading.
+
+      Discarded alternative:
+      - Add more hooks:
+        - pre-upgrade
+          - RBAC should be created/updated during upgrade process
+        - post-upgrade
+          - When upgrading from an old release that does not manage RBAC via hooks - with only the pre-upgrade hook specified - the following happens:
+          - RBAC gets deleted, created, then deleted again
+          - Hacky solution: Also create it in the post-upgrade step.
+          - Since we have the before-hook-creation hook-delete-policy the object will be deleted and recreated if it already exists.
+      - Discarded because:
+        - If we manage RBAC by hooks, we cannot downgrade to an older version that does not manage RBAC by hooks
+        - We get errors like: "invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "spark-operator-bdenv-v19""
+        - (the RBAC is not managed by the helm release lifecycle if it is created via helm hooks)
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-operator.fullname" . }}
-  annotations:
-    "helm.sh/hook": pre-install, pre-upgrade, post-upgrade
+  annotations: {}
+    {{- /*
+    "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    */}}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 rules:
@@ -130,9 +139,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "spark-operator.fullname" . }}
-  annotations:
-    "helm.sh/hook": pre-install, pre-upgrade, post-upgrade
+  annotations: {}
+    {{- /*
+    "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
+    */}}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 subjects:

--- a/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
@@ -9,7 +9,7 @@
         - The webhook cleanup job already deletes the init job - so it should go away in most cases before being run again
         - We set a short TTL-after-competion on the job. This makes it go away, and allows a re-run on upgrades.
           - However, the TTL controller was not enabled by default until k8s 1.21 (https://v1-20.docs.kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
-        - We also make sure (in bigdata-operator) that all webhook init jobs that may still be present are deleted before upgrading.
+        - We can also make sure (in bigdata-operator) that all webhook init jobs that may still be present are deleted before upgrading.
 
       Discarded alternative:
       - Add more hooks:

--- a/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
@@ -1,10 +1,29 @@
 {{- if or .Values.rbac.create .Values.rbac.createClusterRole }}
+{{- /*
+      Helm hook changes by OfAS:
+      Added:
+      - pre-upgrade
+        - RBAC should be created/updated during upgrade process
+      - post-upgrade
+        - When upgrading from an old release that does not manage RBAC via hooks - with only the pre-upgrade hook specified - the following happens:
+        - RBAC gets deleted, created, then deleted again
+        - Hacky solution: Also create it in the post-upgrade step.
+        - Since we have the before-hook-creation hook-delete-policy the object will be deleted and recreated if it already exists.
+
+      Discarded alternative:
+      - Don't manage RBAC via helm hooks
+      - Don't run the webhook init job via helm hook - therefore we don't need to create the RBAC in a hook either.
+      - However, the webhook cleanup job is run by a helm hook - deleting webhook certs on deletion and upgrades.
+      - To make sure that the webhook init job runs on upgrades (even if the yaml was not changed), we set a short TTL-after-competion on the job.
+      - This makes it go away, and be re-run on upgrades.
+      - Discarded because the TTL controller was not enabled by default until k8s 1.21 (https://v1-20.docs.kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/)
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "spark-operator.fullname" . }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade, post-upgrade
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
@@ -112,7 +131,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "spark-operator.fullname" . }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade, post-upgrade
     "helm.sh/hook-delete-policy": hook-failed, before-hook-creation
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}

--- a/charts/spark-operator/charts/spark-operator/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/webhook-cleanup-job.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:
+  {{- /* Added by OfAS */}}
+  ttlSecondsAfterFinished: {{ .Values.webhook.jobTTLSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "spark-operator.fullname" . }}-webhook-cleanup

--- a/charts/spark-operator/charts/spark-operator/templates/webhook-init-job.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/webhook-init-job.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:
+  {{- /* Added by OfAS */}}
+  ttlSecondsAfterFinished: {{ .Values.webhook.jobTTLSecondsAfterFinished }}
   template:
     metadata:
       name: {{ include "spark-operator.fullname" . }}-webhook-init

--- a/charts/spark-operator/charts/spark-operator/templates/webhook-init-job.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/webhook-init-job.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- toYaml .Values.webhook.initAnnotations | nindent 4 }}
   labels:
     {{- include "spark-operator.labels" . | nindent 4 }}
+    {{- /* Added by OfAS */}}
+    bigdata.spot.io/resource: "spark-operator-webhook-init-job"
 spec:
   {{- /* Added by OfAS */}}
   ttlSecondsAfterFinished: {{ .Values.webhook.jobTTLSecondsAfterFinished }}

--- a/charts/spark-operator/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/charts/spark-operator/values.yaml
@@ -93,19 +93,24 @@ webhook:
   namespaceSelector: ""
   # -- The annotations applied to init job, required to restore certs deleted by the cleanup job during upgrade
   initAnnotations:
-    "helm.sh/hook": pre-install, pre-upgrade
-    "helm.sh/hook-weight": "50"
+    # Changed by OfAS
+    # We do not run the webhook init job in a helm hook
+    # (It is problematic to remove keys in sub-charts, so we do it here instead of in the parent chart (https://github.com/helm/helm/issues/9136))
+    # "helm.sh/hook": pre-install, pre-upgrade
+    # "helm.sh/hook-weight": "50"
+    bigdata.spot.io/resource: "spark-operator-webhook-init-job"
   # -- The annotations applied to the cleanup job, required for helm lifecycle hooks
-  # -- before-hook-creation added by OfAS
-  # -- Note:
-  # -- If no hook deletion policy annotation is specified, the before-hook-creation behavior applies by default
-  # -- Having hook-succeeded _only_ means that we do not have before-hook-creation anymore, and if it fails, we will not be able to re-run it
-  # -- Note: The init job does not have a hook-delete-policy, so it gets the before-hook-creation policy by default. Furthermore, the cleanup job deletes the init job.
   cleanupAnnotations:
     "helm.sh/hook": pre-delete, pre-upgrade
+    # Changed by OfAS
+    # Add before-hook-creation
+    # If no hook-delete-policy annotation is specified, the before-hook-creation behavior applies by default.
+    # Having hook-succeeded _only_ means that we do not have before-hook-creation anymore, and if the job fails, we will not be able to re-run it.
     "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
     # -- Webhook Timeout in seconds
   timeout: 30
+  # Added by OfAS
+  jobTTLSecondsAfterFinished: 300
 
 metrics:
   # -- Enable prometheus metric scraping

--- a/charts/spark-operator/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/charts/spark-operator/values.yaml
@@ -96,9 +96,14 @@ webhook:
     "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "50"
   # -- The annotations applied to the cleanup job, required for helm lifecycle hooks
+  # -- before-hook-creation added by OfAS
+  # -- Note:
+  # -- If no hook deletion policy annotation is specified, the before-hook-creation behavior applies by default
+  # -- Having hook-succeeded _only_ means that we do not have before-hook-creation anymore, and if it fails, we will not be able to re-run it
+  # -- Note: The init job does not have a hook-delete-policy, so it gets the before-hook-creation policy by default. Furthermore, the cleanup job deletes the init job.
   cleanupAnnotations:
     "helm.sh/hook": pre-delete, pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
     # -- Webhook Timeout in seconds
   timeout: 30
 

--- a/charts/spark-operator/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/charts/spark-operator/values.yaml
@@ -98,7 +98,6 @@ webhook:
     # (It is problematic to remove keys in sub-charts, so we do it here instead of in the parent chart (https://github.com/helm/helm/issues/9136))
     # "helm.sh/hook": pre-install, pre-upgrade
     # "helm.sh/hook-weight": "50"
-    bigdata.spot.io/resource: "spark-operator-webhook-init-job"
   # -- The annotations applied to the cleanup job, required for helm lifecycle hooks
   cleanupAnnotations:
     "helm.sh/hook": pre-delete, pre-upgrade

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -15,6 +15,7 @@ spark-operator:  # This section controls the behavior of the spark operator sub-
     enable: true
     # If hostNetwork is set to true it is probably a good idea to change this (e.g. 25554)
     port: 443
+    jobTTLSecondsAfterFinished: 60
 
   serviceAccounts:
     spark:


### PR DESCRIPTION
Helm hook fixes. See comments.

## Tests before environment release

- [x] test on k8s 1.22
- [ ] test on k8s 1.21
- [ ] test on k8s 1.20
- [x] test on k8s 1.19
- [x] test upgrades from old spark-operator
- [ ] hostnetworking should still work (test on calico cluster)