### PR TITLE
Bump requests

### DIFF
--- a/charts/bigdata-notebook-service-storage-server/Chart.yaml
+++ b/charts/bigdata-notebook-service-storage-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service-storage-server
 description: A Helm chart for the Spot Big Data Notebook Service Storage Server
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.8"
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service-storage-server/values.yaml
+++ b/charts/bigdata-notebook-service-storage-server/values.yaml
@@ -33,8 +33,8 @@ resources:
     cpu: 500m
     memory: 500Mi
   requests:
-    cpu: 50m
-    memory: 50Mi
+    cpu: 300m
+    memory: 500Mi
 
 nodeSelector: {}
 

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.1.20
+version: 0.1.21
 appVersion: 0.1.19
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -43,8 +43,8 @@ resources:
     cpu: 500m
     memory: 500Mi
   requests:
-    cpu: 50m
-    memory: 50Mi
+    cpu: 500m
+    memory: 500Mi
 
 nodeSelector: {}
 

--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -55,8 +55,8 @@ resources:
     cpu: 500m
     memory: 500Mi
   requests:
-    cpu: 50m
-    memory: 50Mi
+    cpu: 500m
+    memory: 500Mi
 
 nodeSelector: {}
 

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -55,8 +55,8 @@ resources:
     cpu: 500m
     memory: 500Mi
   requests:
-    cpu: 50m
-    memory: 50Mi
+    cpu: 500m
+    memory: 500Mi
 
 nodeSelector: {}
 

--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.4
+version: 0.1.5
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -23,8 +23,8 @@ spark-operator:  # This section controls the behavior of the spark operator sub-
 
   resources:
     requests:
-      cpu: 200m
-      memory: 50Mi
+      cpu: 500m
+      memory: 500Mi
 
   rbac:
     createClusterRole: true  # This one is part of the blue/green


### PR DESCRIPTION
Increase requests.

This will put us at 3 vCPU requested, and 3500 MiB, total.

With the increases for spark-operator, bigdata-spark-watcher, bigdata-proxy, we were already above 2 vCPU (`$family.large`), so I also increased bigdata-operator and bigdata-notebook-service-storage-server.