### PR TITLE
bigdata-spark-watcher 0.2.5

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -3,7 +3,7 @@ name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
 version: 0.2.5
-appVersion: 0.2.1
+appVersion: 0.2.2
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.2.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/templates/role.yaml
+++ b/charts/bigdata-spark-watcher/templates/role.yaml
@@ -12,12 +12,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -49,3 +43,22 @@ rules:
   - patch
   - update
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bigdata-spark-watcher.fullname" . }}
+  namespace: {{ .Values.sparkAppsNamespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create

--- a/charts/bigdata-spark-watcher/templates/role_binding.yaml
+++ b/charts/bigdata-spark-watcher/templates/role_binding.yaml
@@ -11,3 +11,17 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "bigdata-spark-watcher.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bigdata-spark-watcher.fullname" . }}
+  namespace: {{ .Values.sparkAppsNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bigdata-spark-watcher.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bigdata-spark-watcher.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -22,9 +22,9 @@ envVars:
   - name: APP_SYNC_PERIOD
     value: 5m
   - name: APP_SYNC_KILL_GRACE_PERIOD
-    value: 10m
+    value: 5m
   - name: APP_SYNC_GHOST_GRACE_PERIOD
-    value: 10m
+    value: 5m
 
 # Spark Application watch label - used to select sparkApplication custom resources
 saWatchLabel: ""
@@ -52,11 +52,11 @@ securityContext: {}
 
 resources:
   limits:
-    cpu: 1000m
-    memory: 1000Mi
+    cpu: 2000m
+    memory: 2000Mi
   requests:
-    cpu: 1000m
-    memory: 1000Mi
+    cpu: 2000m
+    memory: 2000Mi
 
 nodeSelector: {}
 

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.2.1-a9e38a79
+  tag: 0.2.2-dfba6cb5
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull
@@ -25,9 +25,13 @@ envVars:
     value: 5m
   - name: APP_SYNC_GHOST_GRACE_PERIOD
     value: 5m
+  - name: CREDS_REFRESH_INTERVAL
+    value: 5m
 
 # Spark Application watch label - used to select sparkApplication custom resources
 saWatchLabel: ""
+
+sparkAppsNamespace: spark-apps
 
 serviceAccount:
   create: true

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -24,7 +24,7 @@ envVars:
   - name: APP_SYNC_KILL_GRACE_PERIOD
     value: 5m
   - name: APP_SYNC_GHOST_GRACE_PERIOD
-    value: 5m
+    value: 6m
   - name: CREDS_REFRESH_INTERVAL
     value: 5m
 


### PR DESCRIPTION
* bump resources - previous resources were not enough in a high volume cluster
* reduce kill and ghost grace periods, they were unnecessarily high (the k8s commands have a 5 min timeout)
* bump to version 0.2.2 (kill sync reworked, creds refresh)
* adds pod delete permission in spark-apps namespace, which was missing