### PR TITLE
bigdata-notebook-service 0.1.20

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.1.19
+version: 0.1.20
 appVersion: 0.1.11
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -19,7 +19,7 @@ kernel:
   portMin: 50000  # Port range usable by kernels. Each kernel takes one port.
   portMax: 50100
   launchTimeout: 600  # Timeout for kernel launching in seconds. Nginx timeout is also set to this value.
-  cullIdleTimeout: 3600  # Timeout for an idle kernel before it's culled in seconds. Default is 1 hour.
+  cullIdleTimeout: 0  # Timeout for an idle kernel before it's culled in seconds. 0 turns it off, we use the timeout feature instead.
   connectionServiceName: bigdata-notebook-service-kernel-connection
 
 ingress:


### PR DESCRIPTION
- turn off idle kernel culling, we use the timeout feature instead