### PR TITLE
bigdata-spark-watcher v0.2.12

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.2.11
-appVersion: 0.2.7
+version: 0.2.12
+appVersion: 0.2.8
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/templates/role.yaml
+++ b/charts/bigdata-spark-watcher/templates/role.yaml
@@ -24,13 +24,11 @@ rules:
   - sparkoperator.k8s.io
   resources:
   - sparkapplications
+  - sparkapplications/status
   - scheduledsparkapplications
+  - scheduledsparkapplications/status
   verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - delete
+  - "*"
 - apiGroups:
   - ""
   resources:

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.2.7-92eaf3c7
+  tag: 0.2.8-dbef687c
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull


### PR DESCRIPTION
- clear executor statuses if request is too large error (executor storms)