### PR TITLE
[BGD-2938] Spark app namespaces

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -3,7 +3,7 @@ name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
 version: 0.1.20
-appVersion: 0.1.11
+appVersion: 0.1.12
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 maintainers:

--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.1.20
+version: 0.1.21
 appVersion: 0.1.12
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/templates/deployment.yaml
+++ b/charts/bigdata-notebook-service/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
           - name: EG_KERNEL_LAUNCH_TIMEOUT
             value: {{ .Values.kernel.launchTimeout | quote }}
           - name: OFAS_KERNEL_NAMESPACE
-            value: {{ .Values.kernel.namespace }}
+            value: {{ .Values.kernel.defaultNamespace }}
           - name: SPOTINST_BASE_URL
             value: {{ .Values.spotBaseUrl }}
           - name: EG_RESPONSE_IP

--- a/charts/bigdata-notebook-service/templates/role.yaml
+++ b/charts/bigdata-notebook-service/templates/role.yaml
@@ -11,11 +11,11 @@ rules:
   verbs:
   - get
 ---
+# TODO Should be restricted to spark app namespaces
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "bigdata-notebook-service.fullname" . }}-pod-watcher
-  namespace: {{ .Values.kernel.namespace }}
 rules:
 - apiGroups:
   - ""

--- a/charts/bigdata-notebook-service/templates/role_binding.yaml
+++ b/charts/bigdata-notebook-service/templates/role_binding.yaml
@@ -14,13 +14,12 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "bigdata-notebook-service.fullname" . }}-pod-watcher
-  namespace: {{ .Values.kernel.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "bigdata-notebook-service.fullname" . }}-pod-watcher
 subjects:
 - kind: ServiceAccount

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -15,7 +15,7 @@ imagePullSecrets:
 port: 8888
 
 kernel:
-  defaultNamespace: "spark-apps" # Default kernel namespace
+  defaultNamespace: "spark-apps"  # Default kernel namespace
   portMin: 50000  # Port range usable by kernels. Each kernel takes one port.
   portMax: 50100
   launchTimeout: 600  # Timeout for kernel launching in seconds. Nginx timeout is also set to this value.

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -5,12 +5,12 @@
 replicaCount: 1
 
 image:
-  repository: 598800841386.dkr.ecr.us-east-2.amazonaws.com/private/bigdata-notebook-service
+  repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-notebook-service
   pullPolicy: IfNotPresent
-  tag: bgd-2784-multiple-app-namespaces
+  tag: bcda54d9
 
 imagePullSecrets:
-  - name: spot-bigdata-image-pull-dev
+  - name: spot-bigdata-image-pull
 
 port: 8888
 

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -5,17 +5,17 @@
 replicaCount: 1
 
 image:
-  repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-notebook-service
+  repository: 598800841386.dkr.ecr.us-east-2.amazonaws.com/private/bigdata-notebook-service
   pullPolicy: IfNotPresent
-  tag: d5d1f6fe
+  tag: bgd-2784-multiple-app-namespaces
 
 imagePullSecrets:
-  - name: spot-bigdata-image-pull
+  - name: spot-bigdata-image-pull-dev
 
 port: 8888
 
 kernel:
-  namespace: "spark-apps"
+  defaultNamespace: "spark-apps" # Default kernel namespace
   portMin: 50000  # Port range usable by kernels. Each kernel takes one port.
   portMax: 50100
   launchTimeout: 600  # Timeout for kernel launching in seconds. Nginx timeout is also set to this value.

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.1.29
+version: 0.1.30
 appVersion: 0.1.29
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
 version: 0.1.29
-appVersion: 0.1.27
+appVersion: 0.1.29
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-operator/templates/role.yaml
+++ b/charts/bigdata-operator/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "bigdata-operator.fullname" . }}
+  name: {{ include "bigdata-operator.fullname" . }}-manager
 rules:
   - apiGroups:
       - ""

--- a/charts/bigdata-operator/templates/role_binding.yaml
+++ b/charts/bigdata-operator/templates/role_binding.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "bigdata-operator.fullname" . }}
+  name: {{ include "bigdata-operator.fullname" . }}-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "bigdata-operator.fullname" . }}
+  name: {{ include "bigdata-operator.fullname" . }}-manager
 subjects:
   - kind: ServiceAccount
     name: {{ include "bigdata-operator.serviceAccountName" . }}

--- a/charts/bigdata-operator/templates/role_binding.yaml
+++ b/charts/bigdata-operator/templates/role_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: {{ include "bigdata-operator.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "bigdata-operator.serviceAccountName" . }}

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: public.ecr.aws/f4k1p1n4/bigdata-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.1.27-9c433514
+  tag: 0.1.29-e3b4cb9f
 
 imagePullSecrets: []
 

--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: 0.2.4
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -3,7 +3,7 @@ name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
 version: 0.2.8
-appVersion: 0.2.3
+appVersion: 0.2.4
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-proxy/templates/deployment.yaml
+++ b/charts/bigdata-proxy/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: BIGDATA_PROXY_EVENT_TIMEOUT
               value: "{{ .Values.eventTimeout }}"
             - name: BIGDATA_PROXY_APPS_NAMESPACE
-              value: "{{ .Values.sparkAppsNamespace }}"
+              value: "{{ .Values.defaultSparkAppsNamespace }}"
             - name: BIGDATA_PROXY_LOG_LEVEL
               value: "{{ .Values.logLevel }}"
           resources:

--- a/charts/bigdata-proxy/templates/role.yaml
+++ b/charts/bigdata-proxy/templates/role.yaml
@@ -61,11 +61,11 @@ rules:
       - list
       - watch
 ---
+# TODO Should be restricted to spark app namespaces
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "bigdata-proxy.fullname" . }}-spark-monitor
-  namespace: {{ .Values.sparkAppsNamespace }}
   labels:
     {{- include "bigdata-proxy.labels" . | nindent 4 }}
 rules:

--- a/charts/bigdata-proxy/templates/rolebinding.yaml
+++ b/charts/bigdata-proxy/templates/rolebinding.yaml
@@ -15,15 +15,14 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "bigdata-proxy.fullname" . }}-spark-monitor
-  namespace: {{ .Values.sparkAppsNamespace }}
   labels:
     {{- include "bigdata-proxy.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "bigdata-proxy.fullname" . }}-spark-monitor
 subjects:
   - kind: ServiceAccount

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -5,18 +5,18 @@
 replicaCount: 1
 
 image:
-  repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-proxy
+  repository: 598800841386.dkr.ecr.us-east-2.amazonaws.com/private/bigdata-proxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.2.3-f470a2fe
+  tag: bgd-2951-multiple-namespaces
 
 imagePullSecrets:
-  - name: spot-bigdata-image-pull
+  - name: spot-bigdata-image-pull-dev
 
 port: 8080
 logLimit: 0
 eventTimeout: 10m
-sparkAppsNamespace: spark-apps
+defaultSparkAppsNamespace: spark-apps
 logLevel: info
 
 ingress:

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -5,13 +5,13 @@
 replicaCount: 1
 
 image:
-  repository: 598800841386.dkr.ecr.us-east-2.amazonaws.com/private/bigdata-proxy
+  repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-proxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: bgd-2951-multiple-namespaces
+  tag: 0.2.4-d0e4777e
 
 imagePullSecrets:
-  - name: spot-bigdata-image-pull-dev
+  - name: spot-bigdata-image-pull
 
 port: 8080
 logLimit: 0

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: 0.2.9
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -3,7 +3,7 @@ name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
 version: 0.2.12
-appVersion: 0.2.8
+appVersion: 0.2.9
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/templates/role.yaml
+++ b/charts/bigdata-spark-watcher/templates/role.yaml
@@ -44,11 +44,11 @@ rules:
   - update
   - watch
 ---
+# TODO Should be restricted to spark app namespaces
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  name: {{ include "bigdata-spark-watcher.fullname" . }}
-  namespace: {{ .Values.sparkAppsNamespace }}
+  name: {{ include "bigdata-spark-watcher.fullname" . }}-killer
 rules:
 - apiGroups:
   - ""

--- a/charts/bigdata-spark-watcher/templates/role_binding.yaml
+++ b/charts/bigdata-spark-watcher/templates/role_binding.yaml
@@ -13,14 +13,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: {{ include "bigdata-spark-watcher.fullname" . }}
-  namespace: {{ .Values.sparkAppsNamespace }}
+  name: {{ include "bigdata-spark-watcher.fullname" . }}-killer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "bigdata-spark-watcher.fullname" . }}
+  kind: ClusterRole
+  name: {{ include "bigdata-spark-watcher.fullname" . }}-killer
 subjects:
   - kind: ServiceAccount
     name: {{ include "bigdata-spark-watcher.serviceAccountName" . }}

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -5,13 +5,13 @@
 replicaCount: 1
 
 image:
-  repository: 598800841386.dkr.ecr.us-east-2.amazonaws.com/private/bigdata-spark-watcher
-  pullPolicy: Always
+  repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: bgd-2961-multiple-spark-namespaces
+  tag: 0.2.9-7ac4275e
 
 imagePullSecrets:
-  - name: spot-bigdata-image-pull-dev
+  - name: spot-bigdata-image-pull
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -41,8 +41,6 @@ replicaTagger:
 
 logLevel: debug
 
-sparkAppsNamespace: spark-apps
-
 serviceAccount:
   create: true
   annotations: {}

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -5,13 +5,13 @@
 replicaCount: 1
 
 image:
-  repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
-  pullPolicy: IfNotPresent
+  repository: 598800841386.dkr.ecr.us-east-2.amazonaws.com/private/bigdata-spark-watcher
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.2.8-dbef687c
+  tag: bgd-2961-multiple-spark-namespaces
 
 imagePullSecrets:
-  - name: spot-bigdata-image-pull
+  - name: spot-bigdata-image-pull-dev
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.17
+version: 0.1.18
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -1,5 +1,5 @@
 spark-operator:  # This section controls the behavior of the spark operator sub-chart
-  sparkJobNamespace: spark-apps
+  sparkJobNamespace: "" # Empty means manage Spark apps in all namespaces
   image:
     repository: public.ecr.aws/ocean-spark/spark-operator
     tag: 057db89-dm18

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -1,5 +1,5 @@
 spark-operator:  # This section controls the behavior of the spark operator sub-chart
-  sparkJobNamespace: "" # Empty means manage Spark apps in all namespaces
+  sparkJobNamespace: ""  # Empty means manage Spark apps in all namespaces
   image:
     repository: public.ecr.aws/ocean-spark/spark-operator
     tag: bc88547-gen19


### PR DESCRIPTION
Update images with support for multiple spark app namespaces, and expand roles to allow app runs in more namespaces
- bigdata-notebook-service 0.1.21
- bigdata-operator 0.1.30
- bigdata-proxy 0.2.9
- bigdata-spark-watcher 0.2.13
- spark-operator 0.1.18