### PR TITLE
add tolerations for kubernetes.azure.com/scalesetpriority taints

### DIFF
--- a/charts/bigdata-notebook-service-storage-server/Chart.yaml
+++ b/charts/bigdata-notebook-service-storage-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service-storage-server
 description: A Helm chart for the Spot Big Data Notebook Service Storage Server
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "1.1.0-ofas"
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service-storage-server/values.yaml
+++ b/charts/bigdata-notebook-service-storage-server/values.yaml
@@ -43,6 +43,10 @@ tolerations:
   operator: "Equal"
   value: "ocean-spark-system"
   effect: "NoSchedule"
+- key: "kubernetes.azure.com/scalesetpriority"
+  operator: "Equal"
+  value: "spot"
+  effect: "NoSchedule"
 
 affinity:
   nodeAffinity:

--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: 0.1.12
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -78,6 +78,10 @@ tolerations:
   operator: "Equal"
   value: "ocean-spark-system"
   effect: "NoSchedule"
+- key: "kubernetes.azure.com/scalesetpriority"
+  operator: "Equal"
+  value: "spot"
+  effect: "NoSchedule"
 
 affinity:
   nodeAffinity:

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.1.30
+version: 0.1.31
 appVersion: 0.1.29
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -53,6 +53,10 @@ tolerations:
   operator: "Equal"
   value: "ocean-spark-system"
   effect: "NoSchedule"
+- key: "kubernetes.azure.com/scalesetpriority"
+  operator: "Equal"
+  value: "spot"
+  effect: "NoSchedule"
 
 affinity:
   nodeAffinity:

--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: 0.2.4
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -66,6 +66,10 @@ tolerations:
   operator: "Equal"
   value: "ocean-spark-system"
   effect: "NoSchedule"
+- key: "kubernetes.azure.com/scalesetpriority"
+  operator: "Equal"
+  value: "spot"
+  effect: "NoSchedule"
 
 affinity:
   nodeAffinity:

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: 0.2.9
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -77,6 +77,10 @@ tolerations:
   operator: "Equal"
   value: "ocean-spark-system"
   effect: "NoSchedule"
+- key: "kubernetes.azure.com/scalesetpriority"
+  operator: "Equal"
+  value: "spot"
+  effect: "NoSchedule"
 
 affinity:
   nodeAffinity:

--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.18
+version: 0.1.19
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -53,6 +53,10 @@ spark-operator:  # This section controls the behavior of the spark operator sub-
     operator: "Equal"
     value: "ocean-spark-system"
     effect: "NoSchedule"
+  - key: "kubernetes.azure.com/scalesetpriority"
+    operator: "Equal"
+    value: "spot"
+    effect: "NoSchedule"
 
   rbac:
     createClusterRole: true  # This one is part of the blue/green


### PR DESCRIPTION
Azure adds a taint to all Spot nodes.

See: https://learn.microsoft.com/en-us/azure/aks/spot-node-pool#verify-the-spot-node-pool

We add a toleration for this taint to our system pods. We want to choose if they run on OD or spot using the `spotinst.io/node-lifecycle: od/spot` pod affinities - so it works the same on all cloud providers.