### PR TITLE
BGD-3099-websocket-connection-dropped-if-large-messages

### DIFF
--- a/charts/bigdata-notebook-service/templates/deployment.yaml
+++ b/charts/bigdata-notebook-service/templates/deployment.yaml
@@ -94,6 +94,8 @@ spec:
             value: "{{ sub .Values.kernel.portMax .Values.kernel.portMin }}"
           - name: EG_KERNEL_SESSION_PERSISTENCE
             value: "True"
+          - name: EG_RESPONSE_ADDR_ANY
+            value: "True"
           - name: EG_PERSISTENCE_ROOT
             value: "/mnt"
           - name: SPOTINST_CLUSTER_ID


### PR DESCRIPTION
[BGD-3099] https://spotinst.atlassian.net/browse/BGD-3099

Add allo any response address environment variable needed for new version of enterprise gateway

[BGD-3099]: https://spotinst.atlassian.net/browse/BGD-3099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ