### PR TITLE
Support Ocean controller in arbitrary namespace

### DIFF
--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.1.33
-appVersion: 0.1.33
+version: 0.1.34
+appVersion: 0.1.35
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: public.ecr.aws/f4k1p1n4/bigdata-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.1.33-1b135f46
+  tag: 0.1.35-e3b6c65f
 
 imagePullSecrets: []
 

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.2.15
-appVersion: 0.2.11
+version: 0.2.16
+appVersion: 0.2.12
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.2.11-6d8d8013
+  tag: 0.2.12-dddeb545
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull


### PR DESCRIPTION
* bigdata-operator 0.1.34
  * Use annotation operator.bigdata.spot.io/operatorNamespace
  * Support Ocean controller in arbitrary namespace
* bigdata-spark-watcher 0.2.16
  * Support Ocean controller in arbitrary namespace   