### PR TITLE
Adding delete pod rights to proxy resource monitor role

### DIFF
--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.3.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/templates/role.yaml
+++ b/charts/bigdata-proxy/templates/role.yaml
@@ -20,6 +20,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+  - apiGroups:
       - "apps"
     resources:
       - deployments


### PR DESCRIPTION
We need to add an extra privilege to the bigdata proxy to be able to delete pods