### PR TITLE
version bump

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -3,7 +3,7 @@ name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
 version: 0.4.2
-appVersion: 0.4.1
+appVersion: 0.4.2
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: 0.4.2
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.4.1-a2cd976a
+  tag: 0.4.2-b236bf24
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull


### PR DESCRIPTION
bigdata-spark-watcher version bump, handling executor storms after application has started running

# Jira Ticket

[BGD-3700](https://spotinst.atlassian.net/browse/BGD-3700)

# Checklist:
- [x] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [x] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 


[BGD-3700]: https://spotinst.atlassian.net/browse/BGD-3700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ