### PR TITLE
Ingress Proxy read timeout set to 600 seconds

### DIFF
--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.5.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/templates/ingress.yaml
+++ b/charts/bigdata-proxy/templates/ingress.yaml
@@ -11,6 +11,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
     # Secret containing the trusted ca certificates
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ printf "%s/%s" .Values.ingress.secretNamespace .Values.ingress.secretName }}
+    # Override proxy timeout to give time for possible cluster scale up
+    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.ingress.readTimeout | quote }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:  

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -24,6 +24,7 @@ ingress:
   create: true
   prefixPath: ""  # Defaults to bigdata-proxy.fullname
   ingressClassName: spot-bigdata-nginx
+  readTimeout: 600
   host: ""  # Overridden at deploy time
   secretNamespace: ""  # Overridden at deploy time
   secretName: ""  # Overridden at deploy time


### PR DESCRIPTION
The bigdata proxy is now proxying requests into the notebook service, this means that calls to the session creation can take a long time.

We will need to increase the `nginx` → `upstream` timeout

# Jira Ticket
https://spotinst.atlassian.net/browse/BGD-4148