### PR TITLE
[charts/bigdata-operator] release version 0.4.7 of bigdata-operator

### DIFF
--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.4.7
-appVersion: 0.4.5
+version: 0.4.8
+appVersion: 0.4.7
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: public.ecr.aws/f4k1p1n4/bigdata-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.4.5-4828c9ec
+  tag: 0.4.7-5cf3b94b
 
 imagePullSecrets: []
 
@@ -90,10 +90,10 @@ telemetry:
             Add ClusterId ${CLUSTER_ID}
             Add AccountID ${ACCOUNT_ID}
 
-        # [FILTER]
-        #     Name    grep
-        #     Match   kube.*
-        #     Regex   $kubernetes['labels']['bigdata.spot.io/component'] .
+        [FILTER]
+            Name    grep
+            Match   kube.*
+            Regex   $kubernetes['labels']['bigdata.spot.io/component'] .
 
         [OUTPUT]
             Name s3
@@ -101,8 +101,8 @@ telemetry:
             bucket                       ${AWS_BUCKET_NAME}
             region                       ${AWS_REGION}
             use_put_object               On
-            total_file_size              10M
-            upload_timeout               15m
+            total_file_size              5M
+            upload_timeout               5m
 
 resources:
   limits:


### PR DESCRIPTION
- Release version 0.4.7 of the operator with better support of the telemetry component.
- Enable the filter to collect only ocean spark components logs when telemetry is enabled. 
- Configure the telemetry sidecar to send logs to ocean spark regional bucket every 5 minutes instead of 15.

# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-4710