### PR TITLE
BGD-4696-Fix-jupyterlab-extensions-mechanism

### DIFF
--- a/charts/bigdata-notebook-workspace/templates/deployment.yaml
+++ b/charts/bigdata-notebook-workspace/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - containerPort: {{ .Values.containerPort.port }}
               name: {{ .Values.containerPort.name }}
           command:
-            - start-notebook.sh
+            - start-notebook.py
           args:
           {{- range $key, $value := .Values.server }}
             - --ServerApp.{{ $key | snakecase }}={{$value}}

--- a/charts/bigdata-notebook-workspace/values.yaml
+++ b/charts/bigdata-notebook-workspace/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: public.ecr.aws/ocean-spark/bigdata-notebook
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: lab-4.0.10-ofas-d35201c
+  tag: lab-4.0.11-ofas-3bd43fa
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull
@@ -48,10 +48,6 @@ pvc:
 volume:
   name: workspace-data
   mountPath: /home/jovyan
-
-podSecurityContext:
-  runAsUser: 0
-  fsGroup: 0
 
 containerPort:
   port: 8888


### PR DESCRIPTION
Jupyterlab 4 discourages running as root. The 4.0.11 release requires --allow-root option. We run here as the jovyan user.

# Jira Ticket

[BGD-4696](https://spotinst.atlassian.net/browse/BGD-4696)

# Checklist:
- [x] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [x] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
