### PR TITLE
[.github] allow only team-leads to approve PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # the repo. Unless a later match takes precedence,
 # “team-big-data” team members will be requested for
 # review when someone opens a pull request.
-*           @Spotinst/team-bigdata
+*           @Spotinst/team-bigdata-team-leads
 /.github/   @Spotinst/team-bigdata-devops


### PR DESCRIPTION
To minimize the possibility of pushing bugs to customers, PRs for big data charts should only be approved by the team lead.

# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-4803