### PR TITLE
[BGD-4953] increase nginx body size limit

### DIFF
--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: 0.5.3
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/templates/ingress.yaml
+++ b/charts/bigdata-proxy/templates/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ printf "%s/%s" .Values.ingress.secretNamespace .Values.ingress.secretName }}
     # Override proxy timeout to give time for possible cluster scale up
     nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.ingress.readTimeout | quote }}
+    # Override body size to allow file uploads from JupyterLab(workspace)
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.bodySize }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:  

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -28,6 +28,7 @@ ingress:
   host: ""  # Overridden at deploy time
   secretNamespace: ""  # Overridden at deploy time
   secretName: ""  # Overridden at deploy time
+  bodySize: "2M"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-4953

# Demo

This is recording of a 7.4MB file upload to my workspace.
workspace is running on my cluster `manu-dev-3` on which I patch the bigdata-proxy ingress conf adding: 
```
nginx.ingress.kubernetes.io/proxy-body-size: 2M
```

https://github.com/spotinst/bigdata-charts/assets/21658174/d682fd2e-7bde-4ca9-9175-97424a547911

Ingress conf :
![Screenshot 2024-03-26 at 18 20 45](https://github.com/spotinst/bigdata-charts/assets/21658174/640a7c0d-6f7d-4be6-8511-16011089ac2c)


CP ingress was running with charts from this PR : spotinst/bigdata-internal-charts#392


# Why 

When uploading files from JupyterLab, the chunks sometimes are bigger than the expected 1MB.
Nginx returns `a 413 Payload too large` in those cases

# What

This increase the limit to 2MB, it should be enough. Same change will be done in CP ingress