### PR TITLE
[BGD-4990] bump proxy-body-size to 15M to fix workspace

### DIFF
--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: 0.5.3
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -28,7 +28,7 @@ ingress:
   host: ""  # Overridden at deploy time
   secretNamespace: ""  # Overridden at deploy time
   secretName: ""  # Overridden at deploy time
-  bodySize: "2M"
+  bodySize: "15M"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-4990

## Why

Required to enable large file save on workspaces:
Workspace don't save notebook content using chunks like it does for upload, so we need to bump nginx body-size limit to let the request pass and avoid a `413 Payload too large` error

I find 15M to be a fair size for the usage. On ancient jupyter notebook version it was the limit for file upload.
 

## What

bump `bodySize` to `15M`
~~Do I need to bump the chart version as well~~ -> Yes

# Demo
Worked with body-size bumped as well on Control plane with this : spotinst/bigdata-internal-charts#399

Cluster ingress-nginx conf : 
![Screenshot 2024-04-02 at 16 25 18](https://github.com/spotinst/bigdata-charts/assets/21658174/70305518-a491-4819-a90f-afffbd1098c3)



Recording

https://github.com/spotinst/bigdata-charts/assets/21658174/c7a841d5-4985-4397-a50b-e6fff82635ae

