### PR TITLE
[charts/spark-operator] fix indentation in the telemetry sidecar section

### DIFF
--- a/charts/bigdata-telemetry/Chart.yaml
+++ b/charts/bigdata-telemetry/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-telemetry
 description: A Helm chart for the Spot Big Data Telemetry components
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "1.16.0"
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-telemetry/templates/thanos-receiver-service.yaml
+++ b/charts/bigdata-telemetry/templates/thanos-receiver-service.yaml
@@ -18,3 +18,23 @@ spec:
     targetPort: 19291
   selector:
     {{- include "bigdata-telemetry.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bigdata-telemetry.name" . }}-thanos-receiver-svc
+  labels:
+    {{- include "bigdata-telemetry.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  - name: remote-write
+    port: 19291
+    targetPort: 19291
+  selector:
+    {{- include "bigdata-telemetry.selectorLabels" . | nindent 4 }}

--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.27
+version: 0.1.28
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/charts/spark-operator/templates/deployment.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/deployment.yaml
@@ -135,52 +135,52 @@ spec:
         {{- toYaml . | nindent 10 }}
         {{- end }}
       {{- if .Values.telemetry.enabled }}
-        - name: fluentbit
-          image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
-          ports:
-            - name: http
-              containerPort: 2020
-              protocol: TCP
-          env:
-            - name: AWS_BUCKET_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: spot-bigdata-telemetry-creds
-                  key: AWS_BUCKET_NAME
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: spot-bigdata-telemetry-creds
-                  key: AWS_REGION
-            - name: CLUSTER_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: spot-ofas-cluster-info
-                  key: clusterId
-            - name: ACCOUNT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: spot-ofas-cluster-info
-                  key: accountId
-          resources: {}
-          volumeMounts:
-            - name: telementry-global-config
-              mountPath: /fluent-bit/etc/fluent-bit.conf
-              subPath: fluent-bit.conf
-            - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/custom-filters.conf
-              subPath: custom-filters.conf
-            - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/metrics-collection.conf
-              subPath: metrics-collection.conf
-            - name: varlog
-              readOnly: true
-              mountPath: /var/log/
-            - name: varlibdockercontainers
-              readOnly: true
-              mountPath: /var/lib/docker/containers
-            - name: telemetry-aws-credentials
-              mountPath: /root/.aws
+      - name: fluentbit
+        image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+        ports:
+          - name: http
+            containerPort: 2020
+            protocol: TCP
+        env:
+          - name: AWS_BUCKET_NAME
+            valueFrom:
+              secretKeyRef:
+                name: spot-bigdata-telemetry-creds
+                key: AWS_BUCKET_NAME
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: spot-bigdata-telemetry-creds
+                key: AWS_REGION
+          - name: CLUSTER_ID
+            valueFrom:
+              configMapKeyRef:
+                name: spot-ofas-cluster-info
+                key: clusterId
+          - name: ACCOUNT_ID
+            valueFrom:
+              configMapKeyRef:
+                name: spot-ofas-cluster-info
+                key: accountId
+        resources: {}
+        volumeMounts:
+          - name: telementry-global-config
+            mountPath: /fluent-bit/etc/fluent-bit.conf
+            subPath: fluent-bit.conf
+          - name: telementry-custom-config
+            mountPath: /fluent-bit/etc/custom-filters.conf
+            subPath: custom-filters.conf
+          - name: telementry-custom-config
+            mountPath: /fluent-bit/etc/metrics-collection.conf
+            subPath: metrics-collection.conf
+          - name: varlog
+            readOnly: true
+            mountPath: /var/log/
+          - name: varlibdockercontainers
+            readOnly: true
+            mountPath: /var/lib/docker/containers
+          - name: telemetry-aws-credentials
+            mountPath: /root/.aws
       {{- end }}
       {{- if or .Values.webhook.enable (ne (len .Values.volumes) 0) .Values.telemetry.enabled }}
       volumes:

--- a/charts/spark-operator/charts/spark-operator/templates/telemetry_configmap.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/telemetry_configmap.yaml
@@ -16,7 +16,7 @@ data:
     [INPUT]
       name                    prometheus_scrape
       host                    0.0.0.0
-      port                    {{ .Values.metrics.portName }}
+      port                    {{ .Values.metrics.port }}
       tag                     {{ include "spark-operator.fullname" . }}
       metrics_path            {{ .Values.metrics.endpoint }}
       scrape_interval         5s

--- a/charts/spark-operator/charts/spark-operator/templates/telemetry_configmap.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/telemetry_configmap.yaml
@@ -13,6 +13,8 @@ data:
         Regex   $kubernetes['labels']['bigdata.spot.io/component'] {{ index .Values.podLabels "bigdata.spot.io/component" | quote }}
 
   metrics-collection.conf: |
+    ## Configuration for collecting metrics from the spark operator
+    {{- if .Values.metrics.enable }}
     [INPUT]
       name                    prometheus_scrape
       host                    0.0.0.0
@@ -30,4 +32,5 @@ data:
       tls                  off
       tls.verify           off
       Workers              1
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Follows https://github.com/spotinst/bigdata-charts/pull/190: 
- And fixes an indentation issue in the telemetry section in the spark operator deployment
- Fix the port number of the telemetry input config.
- Add a telemetry service with a fixed name to use in the telemetry output plugins.

# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-4866

# Demo

- `helm upgrade spark-operator-bdenv-v74 charts/spark-operator -n spot-system --debug --set telemetry.enabled=true`

# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
