### PR TITLE
[charts/bigdata-notebook-service] Fix volumes in notebook-service when telemtry is enabled

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.1.16
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/templates/deployment.yaml
+++ b/charts/bigdata-notebook-service/templates/deployment.yaml
@@ -32,6 +32,23 @@ spec:
       - name: session-storage
         persistentVolumeClaim:
           claimName: {{ .Values.sessionStoragePvcName }}
+      {{- if .Values.telemetry.enabled }}
+      - name: telementry-global-config
+        configMap:
+          name: bigdata-common-telemetry-fluentbit-cm
+      - name: telementry-custom-config
+        configMap:
+          name: {{ include "bigdata-notebook-service.fullname" . }}-telemetry-cm
+      - name: varlog
+        hostPath:
+          path: /var/log/
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: telemetry-aws-credentials
+        secret:
+          secretName: spot-bigdata-telemetry-creds
+      {{- end }}
       # This initContainers section should not be needed if the
       # securityContext.fsGroup entry above wasn't ignored, but unfortunately
       # it is ignored for NFS volumes:
@@ -185,22 +202,6 @@ spec:
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
               mountPath: /root/.aws
-      volumes:
-        - name: telementry-global-config
-          configMap:
-            name: bigdata-common-telemetry-fluentbit-cm
-        - name: telementry-custom-config
-          configMap:
-            name: {{ include "bigdata-notebook-service.fullname" . }}-telemetry-cm
-        - name: varlog
-          hostPath:
-            path: /var/log/
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
-        - name: telemetry-aws-credentials
-          secret:
-            secretName: spot-bigdata-telemetry-creds
     {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Follows : https://github.com/spotinst/bigdata-charts/pull/196 and https://github.com/spotinst/bigdata-charts/pull/190 
# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-4866 

# Demo

- Can be tested in a DP cluster with: `helm upgrade bigdata-notebook-service-bdenv-v73 charts/bigdata-notebook-service -n spot-system --debug --set telemetry.enabled=true`


# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
