### PR TITLE
use new bigdata-operator as notebook session backend

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.2.9
-appVersion: 0.82.1
+version: 0.3.0
+appVersion: 0.82.3
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 maintainers:

--- a/charts/bigdata-notebook-service/templates/deployment.yaml
+++ b/charts/bigdata-notebook-service/templates/deployment.yaml
@@ -28,43 +28,24 @@ spec:
       serviceAccountName: {{ include "bigdata-notebook-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      volumes:
-      - name: session-storage
-        persistentVolumeClaim:
-          claimName: {{ .Values.sessionStoragePvcName }}
       {{- if .Values.telemetry.enabled }}
-      - name: telementry-global-config
-        configMap:
-          name: bigdata-common-telemetry-fluentbit-cm
-      - name: telementry-custom-config
-        configMap:
-          name: {{ include "bigdata-notebook-service.fullname" . }}-telemetry-cm
-      - name: varlog
-        hostPath:
-          path: /var/log/
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: telemetry-aws-credentials
-        secret:
-          secretName: spot-bigdata-telemetry-creds
+      volumes:
+        - name: telementry-global-config
+          configMap:
+            name: bigdata-common-telemetry-fluentbit-cm
+        - name: telementry-custom-config
+          configMap:
+            name: {{ include "bigdata-notebook-service.fullname" . }}-telemetry-cm
+        - name: varlog
+          hostPath:
+            path: /var/log/
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: telemetry-aws-credentials
+          secret:
+            secretName: spot-bigdata-telemetry-creds
       {{- end }}
-      # This initContainers section should not be needed if the
-      # securityContext.fsGroup entry above wasn't ignored, but unfortunately
-      # it is ignored for NFS volumes:
-      # https://github.com/kubernetes/examples/issues/260
-      initContainers:
-      - name: nfs-fixer
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-        - name: session-storage
-          mountPath: "/mnt"
-        command:
-        - sh
-        - -c
-        - (chmod 0775 /mnt; chgrp 1000 /mnt)
       containers:
         - name: bigdata-notebook-service
           ports:
@@ -73,9 +54,6 @@ spec:
             protocol: TCP
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          volumeMounts:
-          - name: session-storage
-            mountPath: "/mnt"
           livenessProbe:
             exec:
               command:
@@ -94,7 +72,7 @@ spec:
           - name: EG_NAMESPACE
             value: {{ .Release.Namespace }}
           - name: EG_LIST_KERNELS
-            value: {{ .Values.eglistKernels }}
+            value: {{ .Values.egListKernels }}
           - name: EG_CULL_IDLE_TIMEOUT
             value: {{ .Values.kernel.cullIdleTimeout | quote }}
           - name: EG_LOG_LEVEL
@@ -113,12 +91,16 @@ spec:
             value: "{{ sub .Values.kernel.portMax .Values.kernel.portMin }}"
           - name: EG_KERNEL_SESSION_PERSISTENCE
             value: "True"
+          - name: EG_AVAILABILITY_MODE
+            value: "replication"
+          - name: EG_KERNEL_SESSION_MANAGER
+            value: enterprise_gateway.services.sessions.kernelsessionmanager.WebhookKernelSessionManager
+          - name: EG_WEBHOOK_URL
+            value: "http://{{ .Values.sessionStorageServiceName }}.{{ .Release.Namespace }}.svc.cluster.local/kernelSession"
           - name: EG_RESPONSE_ADDR_ANY
             value: "True"
           - name: EG_RESPONSE_PORT
             value: {{ .Values.kernel.egResponsePort | quote }}
-          - name: EG_PERSISTENCE_ROOT
-            value: "/mnt"
           - name: SPOTINST_CLUSTER_ID
             valueFrom:
               configMapKeyRef:
@@ -143,7 +125,7 @@ spec:
                 optional: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-    {{- if .Values.telemetry.enabled }}
+      {{- if .Values.telemetry.enabled }}
         - name: fluentbit
           image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
           ports:
@@ -205,7 +187,7 @@ spec:
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
               mountPath: /root/.aws
-    {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-notebook-service
   pullPolicy: IfNotPresent
-  tag: 4d9d29b6
+  tag: 01f57ad7
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull
@@ -33,10 +33,11 @@ ingress:
 
 egBaseUrl: "/"
 egLogLevel: "DEBUG"
-egListKernels: "true"
+egListKernels: "True"
 
-# Has to be in sync with bigdata-notebook-service-storage chart
-sessionStoragePvcName: bigdata-notebook-service-storage
+# Has to be in sync with bigdata-operator chart
+sessionStorageServiceName: bigdata-operator-api
+
 
 spotBaseUrl: "https://api.spotinst.io"
 
@@ -56,12 +57,13 @@ podLabels:
 
 podSecurityContext:
   fsGroup: 1000
+  runAsNonRoot: true
 
 securityContext: {}
 
 livenessProbe:
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 10
+  periodSeconds: 30
   timeoutSeconds: 5
 
 resources:

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.4.13
-appVersion: 0.4.10
+version: 0.4.14
+appVersion: 0.4.11
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-operator/templates/api-service.yaml
+++ b/charts/bigdata-operator/templates/api-service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bigdata-operator.fullname" . }}-api
+  labels:
+  {{- include "bigdata-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: api
+      port: 80
+      protocol: TCP
+      targetPort: api
+  selector:
+  {{- include "bigdata-operator.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/charts/bigdata-operator/templates/deployment.yaml
+++ b/charts/bigdata-operator/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - name: metrics
               containerPort: 8080
               protocol: TCP
+            - name: api
+              containerPort: 18080
+              protocol: TCP
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/bigdata-operator/templates/metric-service.yaml
+++ b/charts/bigdata-operator/templates/metric-service.yaml
@@ -15,3 +15,4 @@ spec:
   {{- include "bigdata-operator.selectorLabels" . | nindent 4 }}
   sessionAffinity: None
   type: ClusterIP
+

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: public.ecr.aws/f4k1p1n4/bigdata-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.4.10-0c4f6b5d
+  tag: 0.4.11-429c6a8f
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## Why

Remove the need for NFS in the notebook-service

## What

- Add a new API in bigdata-operator for remoteKernelSession
- Make the notebook-service use webhookKernelSessionManager w/ the bigdata-operator

## Test plan and results


### API server started
```
2024-04-19T14:33:06Z    INFO    setup    bigdata-operator    {"buildVersion": "0.4.11-429c6a8f", "buildDate": "2024-04-19T13:34:26Z"}
2024-04-19T14:33:06Z    INFO    controller-runtime.metrics    Metrics server is starting to listen    {"addr": ":8080"}
2024-04-19T14:33:06Z    INFO    spotConfigProvider    Found Ocean controller namespace "kube-system"
2024-04-19T14:33:06Z    INFO    setup    oceanControllerNamespace: "kube-system"
2024-04-19T14:33:06Z    INFO    spotConfigProvider    SPOTINST_CLUSTER_IDENTIFIER found in config map kube-system/spotinst-kubernetes-cluster-controller-config
2024-04-19T14:33:06Z    INFO    setup    controllerClusterID: "privatelink-india"
2024-04-19T14:33:06Z    INFO    spotConfigProvider    SPOTINST_BASE_URL found in env var
2024-04-19T14:33:06Z    INFO    spotConfigProvider    SPOTINST_TOKEN found in secret kube-system/spotinst-kubernetes-cluster-controller
2024-04-19T14:33:06Z    INFO    spotConfigProvider    SPOTINST_ACCOUNT found in secret kube-system/spotinst-kubernetes-cluster-controller
2024-04-19T14:33:06Z    INFO    setup    starting API server
2024-04-19T14:33:06Z    INFO    setup    starting manager
2024-04-19T14:33:06Z    INFO    Starting server    {"path": "/metrics", "kind": "metrics", "addr": ":8080"}
2024-04-19T14:33:06Z    INFO    Starting server    {"kind": "health probe", "addr": ":8082"}
I0419 14:33:06.997726       1 leaderelection.go:248] attempting to acquire leader lease spot-system/6aaa1a16.spot.io...
I0419 14:33:22.775233       1 leaderelection.go:258] successfully acquired lease spot-system/6aaa1a16.spot.io
```

### Notebook-service using bigdata-operator as backend
```
Starting Jupyter Enterprise Gateway...
[D 2024-04-19 14:45:58.877 EnterpriseGatewayApp] Searching ['/venv/etc/jupyter', '/app/services/bigdata-notebook-service/.jupyter', '/usr/local/etc/jupyter', '/etc/jupyter'] for config files
[D 2024-04-19 14:45:58.878 EnterpriseGatewayApp] Looking for jupyter_config in /etc/jupyter
[D 2024-04-19 14:45:58.878 EnterpriseGatewayApp] Looking for jupyter_config in /usr/local/etc/jupyter
[D 2024-04-19 14:45:58.878 EnterpriseGatewayApp] Looking for jupyter_config in /app/services/bigdata-notebook-service/.jupyter
[D 2024-04-19 14:45:58.879 EnterpriseGatewayApp] Looking for jupyter_config in /venv/etc/jupyter
[D 2024-04-19 14:45:58.880 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /etc/jupyter
[D 2024-04-19 14:45:58.880 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /usr/local/etc/jupyter
[D 2024-04-19 14:45:58.880 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /app/services/bigdata-notebook-service/.jupyter
[D 2024-04-19 14:45:58.881 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /venv/etc/jupyter
[I 2024-04-19 14:45:58.883 EnterpriseGatewayApp] Initializing BigdataKernelSpecManager
[I 2024-04-19 14:45:58.885 EnterpriseGatewayApp] Webhook kernel session persistence activated
[I 2024-04-19 14:45:58.894 EnterpriseGatewayApp] Jupyter Enterprise Gateway 3.2.2 is available at http://0.0.0.0:8888
[I 240419 14:46:23 web:2348] 200 GET /api (127.0.0.1) 0.85ms
```

```
{"level":"info","service":"kernel-session-manager","httpRequest":{"proto":"HTTP/1.1","remoteIP":"192.168.197.60:56762","requestID":"bigdata-operator-6f684d75bf-56g8c/BtBoDD0yso-000007","requestMethod":"GET","requestPath":"/kernelSession","requestURL":"http://bigdata-operator-api.spot-system.svc.cluster.local/kernelSession"},"httpRequest":{"header":{"accept":"*/*","accept-encoding":"gzip, deflate","connection":"keep-alive","user-agent":"python-requests/2.31.0"},"proto":"HTTP/1.1","remoteIP":"192.168.197.60:56762","requestID":"bigdata-operator-6f684d75bf-56g8c/BtBoDD0yso-000007","requestMethod":"GET","requestPath":"/kernelSession","requestURL":"http://bigdata-operator-api.spot-system.svc.cluster.local/kernelSession","scheme":"http"},"timestamp":"2024-04-19T14:46:53.8236137Z","message":"Request: GET /kernelSession"}
{"level":"info","service":"kernel-session-manager","sessions_found":0,"timestamp":"2024-04-19T14:46:53.827606353Z","message":"list kernel sessions"}
{"level":"info","service":"kernel-session-manager","httpRequest":{"proto":"HTTP/1.1","remoteIP":"192.168.197.60:56762","requestID":"bigdata-operator-6f684d75bf-56g8c/BtBoDD0yso-000007","requestMethod":"GET","requestPath":"/kernelSession","requestURL":"http://bigdata-operator-api.spot-system.svc.cluster.local/kernelSession"},"httpResponse":{"bytes":2,"elapsed":3.990853,"header":{"content-type":"application/json"},"status":200},"timestamp":"2024-04-19T14:46:53.827639366Z","message":"Response: 200 OK"}
```

