### PR TITLE
BGD-5143 - fix `bigdata-spark-watcher` cluster role

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.5.14
+version: 0.5.15
 appVersion: 0.5.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/templates/role.yaml
+++ b/charts/bigdata-spark-watcher/templates/role.yaml
@@ -27,6 +27,7 @@ rules:
       - "configmaps"
     resourceNames:
       - "spotinst-kubernetes-cluster-controller-config"
+      - "ocean-controller-ocean-kubernetes-controller"
     verbs:
       - get
   - apiGroups:
@@ -35,6 +36,7 @@ rules:
       - "secrets"
     resourceNames:
       - "spotinst-kubernetes-cluster-controller"
+      - "ocean-controller-ocean-kubernetes-controller"
       - "spot-bigdata-log-collector-creds"
     verbs:
       - get


### PR DESCRIPTION
update `bigdata-spark-watcher` cluster role, add permissions for `ocean-controller-ocean-kubernetes-controller` CM and secret