### PR TITLE
BGD-5023 - bigdata-operator 0.4.17

### DIFF
--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.4.16
-appVersion: 0.4.13
+version: 0.4.17
+appVersion: 0.4.15
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: public.ecr.aws/f4k1p1n4/bigdata-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.4.13-f45f4416
+  tag: 0.4.15-2b3a64f9
 
 imagePullSecrets: []
 


### PR DESCRIPTION
# Jira Ticket

[BGD-5023](https://spotinst.atlassian.net/browse/BGD-5023)

## Description
Release a new bigdata-operator version that fixes the deprecated Kubernetes APIs when upgrading components
https://github.com/spotinst/bigdata-operator/pull/266

## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results

## Test plan and results
 - upgrade bigdata-charts to the new version
 - the component is up and running
 - follow the test plan from the related bigdata-operator PR mentioned above


[BGD-5023]: https://spotinst.atlassian.net/browse/BGD-5023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ