### PR TITLE
Bgd 5200 non root fluentbit sidecars

### DIFF
--- a/charts/bigdata-notebook-service-storage-server/Chart.yaml
+++ b/charts/bigdata-notebook-service-storage-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service-storage-server
 description: A Helm chart for the Spot Big Data Notebook Service Storage Server
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: "1.2.0-ofas"
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service-storage-server/templates/notebook-service-storage-deployment.yaml
+++ b/charts/bigdata-notebook-service-storage-server/templates/notebook-service-storage-deployment.yaml
@@ -41,6 +41,8 @@ spec:
     {{- if .Values.telemetry.enabled }}
       - name: fluentbit
         image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         ports:
           - name: http
             containerPort: 2020
@@ -69,16 +71,16 @@ spec:
         resources: {}
         volumeMounts:
           - name: telementry-global-config
-            mountPath: /fluent-bit/etc/fluent-bit.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
             subPath: fluent-bit.conf
           - name: telementry-custom-config
-            mountPath: /fluent-bit/etc/custom-filters.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
             subPath: custom-filters.conf
           - name: telementry-global-config
-            mountPath: /fluent-bit/etc/parsers.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
             subPath: parsers.conf
           - name: telementry-custom-config
-            mountPath: /fluent-bit/etc/metrics-collection.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
             subPath: metrics-collection.conf
           - name: varlog
             readOnly: true
@@ -87,7 +89,7 @@ spec:
             readOnly: true
             mountPath: /var/lib/docker/containers
           - name: telemetry-aws-credentials
-            mountPath: /root/.aws
+            mountPath: /.aws
       volumes:
         - name: telementry-global-config
           configMap:

--- a/charts/bigdata-notebook-service-storage-server/values.yaml
+++ b/charts/bigdata-notebook-service-storage-server/values.yaml
@@ -41,7 +41,7 @@ telemetry:
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit
-      tag: 2.0.10
+      tag: 3.0.5
 
 nodeSelector: {}
 

--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.83.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/templates/deployment.yaml
+++ b/charts/bigdata-notebook-service/templates/deployment.yaml
@@ -128,6 +128,8 @@ spec:
       {{- if .Values.telemetry.enabled }}
         - name: fluentbit
           image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 2020
@@ -168,16 +170,16 @@ spec:
           resources: {}
           volumeMounts:
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/fluent-bit.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
               subPath: fluent-bit.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/custom-filters.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
               subPath: custom-filters.conf
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/parsers.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
               subPath: parsers.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/metrics-collection.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
               subPath: metrics-collection.conf
             - name: varlog
               readOnly: true
@@ -186,7 +188,7 @@ spec:
               readOnly: true
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
-              mountPath: /root/.aws
+              mountPath: /.aws
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -55,11 +55,10 @@ podLabels:
   spotinst.io/restrict-scale-down: "true"
   bigdata.spot.io/component: "bigdata-notebook-service"
 
-podSecurityContext:
-  fsGroup: 1000
-  runAsNonRoot: true
+podSecurityContext: {}
 
-securityContext: {}
+securityContext:
+  runAsNonRoot: true
 
 livenessProbe:
   initialDelaySeconds: 10
@@ -79,7 +78,7 @@ telemetry:
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit
-      tag: 2.0.10
+      tag: 3.0.5
 
 nodeSelector: {}
 

--- a/charts/bigdata-notebook-workspace/Chart.yaml
+++ b/charts/bigdata-notebook-workspace/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-workspace
 description: A Helm chart for the Spot Big Data Notebook Workspace
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: 4.1.8-ofas-704f999
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-workspace/templates/deployment.yaml
+++ b/charts/bigdata-notebook-workspace/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
         {{- if .Values.telemetry.enabled }}
         - name: fluentbit
           image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 2020
@@ -119,16 +121,16 @@ spec:
                   key: accountId
           volumeMounts:
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/fluent-bit.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
               subPath: fluent-bit.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/custom-filters.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
               subPath: custom-filters.conf
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/parsers.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
               subPath: parsers.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/metrics-collection.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
               subPath: metrics-collection.conf
             - name: varlog
               readOnly: true
@@ -137,7 +139,7 @@ spec:
               readOnly: true
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
-              mountPath: /root/.aws
+              mountPath: /.aws
       {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- if or .Values.pvc.create .Values.telemetry.enabled }}

--- a/charts/bigdata-notebook-workspace/values.yaml
+++ b/charts/bigdata-notebook-workspace/values.yaml
@@ -35,7 +35,7 @@ telemetry:
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit
-      tag: 2.0.10
+      tag: 3.0.5
 
 podLabels:
   bigdata.spot.io/component: "bigdata-notebook-workspace"

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.4.17
+version: 0.4.18
 appVersion: 0.4.15
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-operator/templates/deployment.yaml
+++ b/charts/bigdata-operator/templates/deployment.yaml
@@ -82,6 +82,8 @@ spec:
             failureThreshold: 3
         - name: fluentbit
           image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 2020
@@ -122,16 +124,16 @@ spec:
           resources: {}
           volumeMounts:
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/fluent-bit.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
               subPath: fluent-bit.conf
+            - name: telementry-custom-config
+              mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
+              subPath: custom-filters.conf
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/parsers.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
               subPath: parsers.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/custom-filters.conf
-              subPath: custom-filters.conf
-            - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/metrics-collection.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
               subPath: metrics-collection.conf
             - name: varlog
               readOnly: true
@@ -140,7 +142,7 @@ spec:
               readOnly: true
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
-              mountPath: /root/.aws
+              mountPath: /.aws
       volumes:
         - name: telementry-global-config
           configMap:

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -49,7 +49,7 @@ telemetry:
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit
-      tag: 2.0.10
+      tag: 3.0.5
 
 resources:
   limits:

--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.4.11
+version: 0.4.12
 appVersion: 0.5.4
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/templates/deployment.yaml
+++ b/charts/bigdata-proxy/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
     {{- if .Values.telemetry.enabled }}
         - name: fluentbit
           image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 2020
@@ -84,16 +86,16 @@ spec:
           resources: {}
           volumeMounts:
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/fluent-bit.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
               subPath: fluent-bit.conf
+            - name: telementry-custom-config
+              mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
+              subPath: custom-filters.conf
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/parsers.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
               subPath: parsers.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/custom-filters.conf
-              subPath: custom-filters.conf
-            - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/metrics-collection.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
               subPath: metrics-collection.conf
             - name: varlog
               readOnly: true
@@ -102,7 +104,7 @@ spec:
               readOnly: true
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
-              mountPath: /root/.aws
+              mountPath: /.aws
       volumes:
         - name: telementry-global-config
           configMap:

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -68,7 +68,7 @@ telemetry:
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit
-      tag: 2.0.10
+      tag: 3.0.5
 
 nodeSelector: {}
 

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.5.15
+version: 0.5.16
 appVersion: 0.5.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/templates/deployment.yaml
+++ b/charts/bigdata-spark-watcher/templates/deployment.yaml
@@ -87,6 +87,8 @@ spec:
     {{- if .Values.telemetry.enabled }}
         - name: fluentbit
           image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 2020
@@ -127,16 +129,16 @@ spec:
           resources: {}
           volumeMounts:
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/fluent-bit.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
               subPath: fluent-bit.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/custom-filters.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
               subPath: custom-filters.conf
             - name: telementry-global-config
-              mountPath: /fluent-bit/etc/parsers.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
               subPath: parsers.conf
             - name: telementry-custom-config
-              mountPath: /fluent-bit/etc/metrics-collection.conf
+              mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
               subPath: metrics-collection.conf
             - name: varlog
               readOnly: true
@@ -145,7 +147,7 @@ spec:
               readOnly: true
               mountPath: /var/lib/docker/containers
             - name: telemetry-aws-credentials
-              mountPath: /root/.aws
+              mountPath: /.aws
     {{- end }}
       {{- if or .Values.telemetry.enabled .Values.k8sEventLogCollectorEnabled }}
       volumes:

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -90,7 +90,7 @@ telemetry:
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit
-      tag: 2.0.10
+      tag: 3.0.5
 
 nodeSelector: {}
 

--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.30
+version: 0.1.31
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/charts/spark-operator/templates/deployment.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/deployment.yaml
@@ -137,6 +137,8 @@ spec:
       {{- if .Values.telemetry.enabled }}
       - name: fluentbit
         image: "{{ .Values.telemetry.fluentbit.image.repository }}:{{ .Values.telemetry.fluentbit.image.tag }}"
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
         ports:
           - name: http
             containerPort: 2020
@@ -165,16 +167,16 @@ spec:
         resources: {}
         volumeMounts:
           - name: telementry-global-config
-            mountPath: /fluent-bit/etc/fluent-bit.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/fluent-bit.conf
             subPath: fluent-bit.conf
           - name: telementry-custom-config
-            mountPath: /fluent-bit/etc/custom-filters.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/custom-filters.conf
             subPath: custom-filters.conf
           - name: telementry-global-config
-            mountPath: /fluent-bit/etc/parsers.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/parsers.conf
             subPath: parsers.conf
           - name: telementry-custom-config
-            mountPath: /fluent-bit/etc/metrics-collection.conf
+            mountPath: /opt/bitnami/fluent-bit/conf/metrics-collection.conf
             subPath: metrics-collection.conf
           - name: varlog
             readOnly: true
@@ -183,7 +185,7 @@ spec:
             readOnly: true
             mountPath: /var/lib/docker/containers
           - name: telemetry-aws-credentials
-            mountPath: /root/.aws
+            mountPath: /.aws
       {{- end }}
       {{- if or .Values.webhook.enable (ne (len .Values.volumes) 0) .Values.telemetry.enabled }}
       volumes:

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -56,7 +56,7 @@ spark-operator:  # This section controls the behavior of the spark operator sub-
     fluentbit:
       image:
         repository: public.ecr.aws/ocean-spark/fluent-bit
-        tag: 2.0.10
+        tag: 3.0.5
 
   tolerations:
   - key: "bigdata.spot.io/unschedulable"


### PR DESCRIPTION
- Use non root container images for telemetry fluent-bit sidecars.
- Use the version fluent-bit 3.0.5 [bitnami non-root images](https://hub.docker.com/layers/bitnami/fluent-bit/3.0.5/images/sha256-f177e1489be0d2c17be2c696e220df118ce0de4e7394f6ad08a935763ba59955?context=explore
) 

⚠️ Needs this PR to be merged and released first https://github.com/spotinst/bigdata-infrastructure/pull/479

# Jira Ticket

https://spotinst.atlassian.net/browse/BGD-5200

# Demo:

After applying the charts (see tests bellow), all components are running with the sidecars as non-root
`kubectl get pods -o jsonpath="{range .items[*]}{'\n'}{.metadata.name}:{range .status.containerStatuses[*]}{'\n\t'}{.name}{'\t'}{.image}{'\t'}{.state}{end}{end}" -n spot-system`

![Screenshot 2024-05-27 at 14 14 04](https://github.com/spotinst/bigdata-charts/assets/35115877/1d07feb1-0da0-4929-9872-92ddf3e42f05)


# Tests

Before applying the charts bellow, set the the telemetry to true

```
  telemetry:
    enabled: true
    fluentbit:
      image:
        repository: public.ecr.aws/ocean-spark/fluent-bit
        tag: 3.0.5
```

### **`Bigdata-noteboook-service`**
apply the charts to a running DP: `helm upgrade bigdata-notebook-service-bdenv-v67 charts/bigdata-notebook-service -n spot-system --debug `

<img width="1414" alt="Screenshot 2024-05-27 at 13 44 49" src="https://github.com/spotinst/bigdata-charts/assets/35115877/b27219b4-0a79-4c01-ab20-96ec9300bf38">

The sidecar is running as non-root (version `3.0.5`)

<img width="1414" alt="Screenshot 2024-05-27 at 13 45 13" src="https://github.com/spotinst/bigdata-charts/assets/35115877/150b99b1-77ec-453b-8bd8-0228e1508477">

### **`Bigdata-operator`**

<img width="1414" alt="Screenshot 2024-05-27 at 13 38 31" src="https://github.com/spotinst/bigdata-charts/assets/35115877/86bc7930-401d-4cbb-b6c5-7a5cacf44a9f">

### **`spark-operator`**

- apply the charts : `helm upgrade spark-operator-bdenv-v67 charts/spark-operator -n spot-system --debug`

<img width="1414" alt="Screenshot 2024-05-27 at 13 58 20" src="https://github.com/spotinst/bigdata-charts/assets/35115877/a31c70d3-db0b-46b1-9a44-dc86666ffc0b">


### **`Bigdata-spark-watcher`**

- `helm upgrade bigdata-spark-watcher-bdenv-v67 charts/bigdata-spark-watcher -n spot-system `

<img width="1414" alt="Screenshot 2024-05-27 at 14 09 36" src="https://github.com/spotinst/bigdata-charts/assets/35115877/cfa1824c-0223-4564-80ab-02e41c7e4df6">


### **`Bigdata-proxy`**

`helm upgrade bigdata-proxy-bdenv-v67 charts/bigdata-proxy -n spot-system`

<img width="1414" alt="Screenshot 2024-05-27 at 14 05 46" src="https://github.com/spotinst/bigdata-charts/assets/35115877/f414eaf0-3c36-4779-aaa5-6a629cf19f44">

The logs from the sidecar :

<img width="1414" alt="Screenshot 2024-05-27 at 14 06 25" src="https://github.com/spotinst/bigdata-charts/assets/35115877/df37181a-000c-4ef7-ac3e-fc7c10e18bf7">



### The cluster is available ✅ :

![Screenshot 2024-05-27 at 14 11 02](https://github.com/spotinst/bigdata-charts/assets/35115877/fe3a1de1-7ac2-49b1-8487-f8156117e582)


# Checklist:
- [x] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
