### PR TITLE
BGD-5256: operator update 0.4.16 - notebook service 0.4.0

### DIFF
--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.4.18
-appVersion: 0.4.15
+version: 0.4.19
+appVersion: 0.4.16
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: public.ecr.aws/f4k1p1n4/bigdata-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.4.15-2b3a64f9
+  tag: 0.4.16-ef993245
 
 imagePullSecrets: []
 


### PR DESCRIPTION
# Jira Ticket
[BGD-5256](https://spotinst.atlassian.net/browse/BGD-5256)

# Demo

Release of the bigdata operator, which contains notebook service update to use new config endpoints.
Related bigdata-operator PR https://github.com/spotinst/bigdata-operator/pull/281

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [x] I have all neccessary approvals for the design/mini design of this task

# Test Plan:

 - helm upgrade from the local chart
 ```
helm upgrade bigdata-operator bigdata-operator -n spot-system --debug
```
<img width="928" alt="image" src="https://github.com/spotinst/bigdata-charts/assets/54230036/8ea7bbfc-ef4c-4502-a6a0-01ebb87173e7">

 - the bigdata-opearator is up and running with the new image tag

<img width="782" alt="image" src="https://github.com/spotinst/bigdata-charts/assets/54230036/b1f0e7e0-1fb9-41d4-be49-c51770c87c63">


[BGD-5256]: https://spotinst.atlassian.net/browse/BGD-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ