### PR TITLE
Bgd-4863 enable telemetry collection

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.83.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -74,7 +74,7 @@ resources:
     memory: 2Gi
 
 telemetry:
-  enabled: false
+  enabled: true
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit

--- a/charts/bigdata-notebook-workspace/Chart.yaml
+++ b/charts/bigdata-notebook-workspace/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-workspace
 description: A Helm chart for the Spot Big Data Notebook Workspace
 type: application
-version: 0.0.14
+version: 0.0.15
 appVersion: 4.1.8-ofas-704f999
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-workspace/values.yaml
+++ b/charts/bigdata-notebook-workspace/values.yaml
@@ -31,7 +31,7 @@ gatewayClient:
   secretKeyToken: token
 
 telemetry:
-  enabled: false
+  enabled: true
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit

--- a/charts/bigdata-operator/Chart.yaml
+++ b/charts/bigdata-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-operator
 description: Spot Ocean BigData Operator
 type: application
-version: 0.4.20
+version: 0.4.21
 appVersion: 0.4.17
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-operator/values.yaml
+++ b/charts/bigdata-operator/values.yaml
@@ -46,7 +46,7 @@ securityContext:
 # runAsUser: 1000
 
 telemetry:
-  enabled: false
+  enabled: true
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit

--- a/charts/bigdata-proxy/Chart.yaml
+++ b/charts/bigdata-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-proxy
 description: A Helm chart for the Spot Big Data Proxy
 type: application
-version: 0.4.12
+version: 0.4.13
 appVersion: 0.5.4
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-proxy/values.yaml
+++ b/charts/bigdata-proxy/values.yaml
@@ -64,7 +64,7 @@ resources:
     memory: 500Mi
 
 telemetry:
-  enabled: false
+  enabled: true
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit

--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.5.17
+version: 0.5.18
 appVersion: 0.5.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -86,7 +86,7 @@ resources:
     memory: 2000Mi
 
 telemetry:
-  enabled: false
+  enabled: true
   fluentbit:
     image:
       repository: public.ecr.aws/ocean-spark/fluent-bit

--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Spark Operator (b/g part)
 name: spark-operator
-version: 0.1.31
+version: 0.1.32
 appVersion: v1beta2-1.3.4-3.1.1
 dependencies:
   - name: spark-operator

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -52,7 +52,7 @@ spark-operator:  # This section controls the behavior of the spark operator sub-
       memory: 1000Mi
 
   telemetry:
-    enabled: false
+    enabled: true
     fluentbit:
       image:
         repository: public.ecr.aws/ocean-spark/fluent-bit


### PR DESCRIPTION
# Jira Ticket

[BGD-4863](https://spotinst.atlassian.net/browse/BGD-4863)

# Test Plan

- upgrade helm charts
  - bigdata-operator
  - spark-watcher
  - bigdata-proxy
  - spark-operator
  - workspace/s

```
helm upgrade bigdata-operator bigdata-operator -n spot-system

helm upgrade bigdata-spark-watcher-{env_version} bigdata-spark-watcher

helm upgrade spark-operator-{env_version} spark-operator -n spot-system

helm upgrade bigdata-proxy-{env_version} bigdata-proxy -n spot-system

helm upgrade bigdata-notebook-service-{env_version} bigdata-notebook-service

helm upgrade wksp-104501-cd3d3eab bigdata-notebook-workspace -n spot-system
```
 - telemetry container is running for each component

<img width="825" alt="image" src="https://github.com/spotinst/bigdata-charts/assets/54230036/a68fcdb2-c785-4512-972e-0aaba4fe17aa">

 - logs for all components are present 
<img width="1388" alt="image" src="https://github.com/spotinst/bigdata-charts/assets/54230036/755be9a8-0ae8-460f-8eaa-1584f7aa5be7">



[BGD-4863]: https://spotinst.atlassian.net/browse/BGD-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ