### PR TITLE
 [.github/workflows] add a new workflow to alert on branch protection changes

### DIFF
--- a/.github/workflows/branch-protection-changes.yaml
+++ b/.github/workflows/branch-protection-changes.yaml
@@ -1,0 +1,35 @@
+name: Branch Protection Change Alert
+
+on:
+  branch_protection_rule:
+    types: [created, edited, deleted]
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set event details
+      id: event_details
+      run: |
+        echo "::set-output name=event_type::${{ github.event.action }}"
+        echo "::set-output name=branch::${{ github.event.rule.pattern }}"
+        echo "::set-output name=actor::${{ github.actor }}"
+        echo "::set-output name=actor_url::https://github.com/${{ github.actor }}"
+
+    - name: Notify the Team on Slack
+      uses: ravsamhq/notify-slack-action@master
+      if: always()
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEVOPS_CHANNEL_WEBHOOK }}
+      with:
+        status: ${{ job.status }}
+        notify_when: "success"
+        mention_groups: "S07C4DA4U5V"
+        notification_title: 'Branch Protection Rule Change'
+        message_format: |
+          ${{ steps.event_details.outputs.event_type }} branch protection rule for `${{ steps.event_details.outputs.branch }}` in ${{ github.repository }}
+          Changed by: <${{ steps.event_details.outputs.actor_url }}|${{ steps.event_details.outputs.actor }}>
+        footer: 'Ocean Spark GitHub Branch Protection Monitor'


### PR DESCRIPTION
Get Alerted when the branch protection rules change

<img width="513" alt="Screenshot 2024-08-28 at 17 42 41" src="https://github.com/user-attachments/assets/913e2d51-e2b6-45d2-9f74-b2299b4726f0">


## Jira ticket

https://spotinst.atlassian.net/browse/BGD-5788

## Checklist

✅ Not a code change and not affecting the current workflows thus all the checks bellow are not applicable