### PR TITLE
[BGD-5797] add bns role to list and patch CR

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.83.0
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-service/Readme.md
+++ b/charts/bigdata-notebook-service/Readme.md
@@ -1,0 +1,11 @@
+# bigdata-notebook-service
+
+## Cluster role
+
+### bigdata-notebook-service-bdenv-vXX-killer
+
+This role is used by bigdata-notebook-service to add the following SparkApp CR annotations:
+```
+bigdata.spot-io/kill-reason
+bigdata.spot-io/kill-requested-at
+```

--- a/charts/bigdata-notebook-service/templates/role.yaml
+++ b/charts/bigdata-notebook-service/templates/role.yaml
@@ -25,3 +25,16 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "bigdata-notebook-service.fullname" . }}-killer
+rules:
+  - apiGroups:
+    - sparkoperator.k8s.io
+    resources:
+    - '*'
+    verbs:
+    - 'list'
+    - 'patch'

--- a/charts/bigdata-notebook-service/templates/role_binding.yaml
+++ b/charts/bigdata-notebook-service/templates/role_binding.yaml
@@ -25,3 +25,16 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "bigdata-notebook-service.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "bigdata-notebook-service.fullname" . }}-killer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "bigdata-notebook-service.fullname" . }}-killer
+subjects:
+- kind: ServiceAccount
+  name: {{ include "bigdata-notebook-service.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-5797

## Description


We want the notebook-service to be able to watch sparkapp CR and add annotations `bigdata.spot.io/kill-requested-at` in them and let spark-watcher kill the app.
This will happen at each kernel shutdown handled by bns


## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results
- [x] I have updated/created relevant documentation

## How to test

- Apply chart on a cluster with `helm upgrade bigdata-notebook-service-bdenv-vXX bigdata-notebook-service -n spot-system`
- Update your bigdata-notebook-service deployment with the image from this PR  spotinst/bigdata-python-services#1332
- Start a notebook and wait for it to be running
- Click on the restart button in JupyterLab UI
- Check notebook-service manage to update the annotation, you should see something like: 
```
Found CRD for this kernel_id=8221eeb6-2b57-42ea-b51f-9cefea265c1f in namespace=spark-apps
Updated annotations for sparkapplication: nb-8221eeb6-2b57-42ea-b51f-9cefea265c1f-84255
```
- Check following annotations are present in sparkapp CR : 
```
bigdata.spot-io/kill-reason
bigdata.spot-io/kill-requested-at
```

## Test plan and results


| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Apply chart  | Pass   |  |
| 2    | Annotation is present on SparkApp CR after kernel restart | Pass   |  |

cluster role binding
![Screenshot 2024-08-29 at 17 59 14](https://github.com/user-attachments/assets/f95e3ad1-5b79-4b5a-ade6-761706ab1001)

cluster role
![Screenshot 2024-08-29 at 17 58 52](https://github.com/user-attachments/assets/1b60c09e-c7af-44c4-974e-8e3c6a583c41)

bigdata-notebook-service logs showing kernel restart + annotation update
![Screenshot 2024-08-29 at 17 58 27](https://github.com/user-attachments/assets/7cd21b74-2829-4ff7-a846-42582ff82bdc)

SparkApp CR with annotations
![Screenshot 2024-08-29 at 17 58 09](https://github.com/user-attachments/assets/1d438d65-5aa4-4bc7-ac95-b9729bac2f28)
