### PR TITLE
[BGD-5896] bns set annotation when shutting down a kernel

### DIFF
--- a/charts/bigdata-notebook-service/Chart.yaml
+++ b/charts/bigdata-notebook-service/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-notebook-service
 description: A Helm chart for the Spot Big Data Notebook Service
 type: application
-version: 0.4.2
-appVersion: 0.83.0
+version: 0.4.3
+appVersion: 0.94.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 maintainers:

--- a/charts/bigdata-notebook-service/values.yaml
+++ b/charts/bigdata-notebook-service/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-notebook-service
   pullPolicy: IfNotPresent
-  tag: c167ac99
+  tag: 9b263003
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-5896

## Description

bigdata-notebook-service nows sets annotation `kill-requested-at` on SparkApp CR when kernel shutdown (or restart) is requested. 
a ClusterRole has been added to allow this behaviour in a previous change.

## Demo

_Please add a recording/screenshot of the feature/bug fix in action_

## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results
- [x] I have updated/created relevant documentation

## How to test

- deploy chart `helm upgrade bigdata-notebook-service-bdenv-v30 bigdata-notebook-service -n spot-system`
- run notebooks
- kill and restart them
- check CR contains `kill-requested-at` annotation


## Test plan and results


| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Chart deployment | Pass   |  |
| 2    | Annotation on killed notebook | Pass   |  |
| 3    | Annotation on restarted notebook | Pass   |  |

![Screenshot 2024-09-13 at 15 57 32](https://github.com/user-attachments/assets/b1c054b6-0c42-4abf-a9d0-4ad42c174dc4)


![Screenshot 2024-09-13 at 17 10 30](https://github.com/user-attachments/assets/d94518c8-e02c-46c5-a16d-74e4af4e375e)
![Screenshot 2024-09-13 at 17 10 45](https://github.com/user-attachments/assets/485d35de-17b9-4e6b-8d84-8aac683686ff)
