### PR TITLE
BGD-6060 Flush events chunks before final heartbeat

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.6.1
+appVersion: 0.6.1
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.6.0-feab5dd0
+  tag: 0.6.1-6818cc04
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-6060

## Description

Update spark-watcher to 0.6.1. Before sending the final heartbeat to an application, make sure that the event cache is flushed to persistent storage.

## Demo

<img width="1696" alt="image" src="https://github.com/user-attachments/assets/dc62e3d1-35e1-4201-bb0b-49f49a483adf">

The apps have the following IDs:
```
│ Labels:           bigdata.spot.io/application-id=andrei-beefed-pi-24dfa-hangs
bigdata.spot.io/application-internal-id=53f827b4-8426-44f2-a2f6-2caf3d4ae617                                                                          

│ Labels:           bigdata.spot.io/application-id=andrei-beefed-pi-29e7a-facts
bigdata.spot.io/application-internal-id=e474666f-52f9-446a-ab86-fdcbf96b016a
                                                                         
```
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/5bead06e-9aa4-4b1e-98ad-2cfd0c4c9f06">

<img width="1531" alt="image" src="https://github.com/user-attachments/assets/1c915734-62a1-43c8-a685-907c23f7d197">

<img width="1604" alt="image" src="https://github.com/user-attachments/assets/150ccab3-bd53-4810-9c7d-505b95484555">

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/36bcb5bd-7ac8-4385-924c-5351379c1990">


## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results
- [x] I have updated/created relevant documentation

## How to test

To test this change, we need a DP cluster. Run a very fast application. Logs should be available in the archive bucket (and available to be downloaded if the feature is enabled in the UI) after the application finishes.

## Test plan and results
### Short app test
1. Run short app
2. Monitor the "Deleting application from event cache" log from the spark-watcher for this application
3. After the log message is displayed, wait for the kubelogs pipeline to be finalized on the control plane. (message on kibana)

#### Expected result:
After the app is finalized in the CP, the archive buckets should contain the event logs (and if the feature is enabled in the UI, the tabulated file should be available for download).

| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Short app test | Pass   | application-internal-id=53f827b4-8426-44f2-a2f6-2caf3d4ae617 (on prod) |
| 2.   | Short app test | Pass | application-internal-id=e474666f-52f9-446a-ab86-fdcbf96b016a  (on prod) |
