### PR TITLE
Run workspace as non root

### DIFF
--- a/charts/bigdata-notebook-workspace/Chart.yaml
+++ b/charts/bigdata-notebook-workspace/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-workspace
 description: A Helm chart for the Spot Big Data Notebook Workspace
 type: application
-version: 0.0.16
+version: 0.0.17
 appVersion: 4.1.8-ofas-31799c9
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-workspace/templates/deployment.yaml
+++ b/charts/bigdata-notebook-workspace/templates/deployment.yaml
@@ -52,8 +52,7 @@ spec:
             - containerPort: {{ .Values.containerPort.port }}
               name: {{ .Values.containerPort.name }}
           command:
-            - start-notebook.sh 
-            - --allow-root
+            - start-notebook.py
           args:
           {{- range $key, $value := .Values.server }}
             - --ServerApp.{{ $key | snakecase }}={{$value}}

--- a/charts/bigdata-notebook-workspace/values.yaml
+++ b/charts/bigdata-notebook-workspace/values.yaml
@@ -58,8 +58,9 @@ volume:
   mountPath: /home/jovyan
 
 podSecurityContext:
-  runAsUser: 0
-  fsGroup: 0
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 100
 
 containerPort:
   port: 8888


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-4766

## Description

Our workspace jupyterlab image is based on the https://quay.io/repository/jupyter/base-notebook image, which has userid 1000 for user jovyan and groupid 100 for group users.

It is recommended to use the start-notebook.py instead of the shell script to launch the jupyterlab process, see.
```sh
cat start-notebook.sh 
#!/bin/bash
# Shim to emit warning and call start-notebook.py
echo "WARNING: Use start-notebook.py instead"

exec /usr/local/bin/start-notebook.py "$@"
```

## Demo

Opening a terminal in the workspace notebook no longer runs as root. Also new notebook files are successfully saved on the mounted drive and owned by the jovyan user.

<img width="928" alt="Screenshot 2024-11-05 at 14 12 53" src="https://github.com/user-attachments/assets/a644ad44-25cd-4d97-8a33-7f322012a145">
<img width="930" alt="Screenshot 2024-11-05 at 14 13 05" src="https://github.com/user-attachments/assets/489920bf-808b-41cd-ae8f-1c8fe4b19216">

## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results
- [x] I have updated/created relevant documentation

## How to test

Create a workspace. Edit the deployment and replace the runAsUser: 0 and fsGroup: 0 with 1000 and 100 respectively. Remove the --allow-root and replace start-notebook.sh with start-notebook.py. Launch a notebook from the workspace and run a spark query. Open a terminal in jupyterlab and touch a file to see if the mount is writable. 

## Test plan and results

_Feel free to add screenshots showing test results_

| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Launch a notebook and run spark.sql("select random()").show() | Pass   | The created notebook file is successfully saved under /home/jovyan  |
| 2    | Open a terminal, touch file.txt | Pass   | Mounted user folder is writable  |