### PR TITLE
BGD-6179 Handle orphaned drivers

### DIFF
--- a/charts/bigdata-spark-watcher/Chart.yaml
+++ b/charts/bigdata-spark-watcher/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bigdata-spark-watcher
 description: A Helm chart for the Spot Big Data Spark Watcher
 type: application
-version: 0.6.3
-appVersion: 0.6.2
+version: 0.6.4
+appVersion: 0.6.3
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png
 sources:

--- a/charts/bigdata-spark-watcher/templates/deployment.yaml
+++ b/charts/bigdata-spark-watcher/templates/deployment.yaml
@@ -75,6 +75,20 @@ spec:
               value: {{ .Values.k8sEventLogCollector.bucketPrefix }}
             - name: KUBE_EVENT_LOG_COLLECTION_ENVIRONMENT
               value: {{ .Values.k8sEventLogCollector.environment }}
+            {{- if or .Values.stuckAppCleanupEnabled .Values.stuckDriverCleanupEnabled }}
+            - name: WATCHER_STUCK_SPARK_APP_CLEANUP_ENABLED
+              value: {{ .Values.stuckAppCleanupEnabled | quote }}
+            - name: WATCHER_STUCK_DRIVER_CLEANUP_ENABLED
+              value: {{ .Values.stuckDriverCleanupEnabled | quote }}
+            {{- with .Values.stuckCleanup }}
+            - name: WATCHER_STUCK_TTL
+              value: {{ .gracePeriod }}
+            - name: WATCHER_STUCK_TTL_LEEWAY
+              value: {{ .leeway }}
+            - name: WATCHER_STUCK_CHECK_FREQUENCY
+              value: {{ .period }}
+            {{- end }}
+            {{- end }}
             - name: AWS_CREDENTIALS_FILE
               value: /creds/aws
             - name: GCP_CREDENTIALS_FILE

--- a/charts/bigdata-spark-watcher/values.yaml
+++ b/charts/bigdata-spark-watcher/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 066597193667.dkr.ecr.us-east-1.amazonaws.com/private/bigdata-spark-watcher
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.6.2-0fdc670d
+  tag: 0.6.3-79527191
 
 imagePullSecrets:
   - name: spot-bigdata-image-pull
@@ -41,6 +41,15 @@ k8sEventLogCollectorEnabled: true
 k8sEventLogCollector:
   bucketPrefix: "spot-bigdata-logcollector"
   environment: ""
+
+# cleans up stuck failed apps without termination times
+stuckAppCleanupEnabled: true
+# cleans up orphaned drivers
+stuckDriverCleanupEnabled: true
+stuckCleanup:
+  gracePeriod: 10m
+  leeway: 2m
+  period: 2m
 
 serviceAccount:
   create: true


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-6179

## Description
Introduces the new env vars required to enable the new cleanup mechanisms for orphaned drivers and stuck failed spark app CRs, as well as bumps the image tag to use the new version.

## Demo
<img width="437" alt="Screenshot 2024-12-06 at 16 20 05" src="https://github.com/user-attachments/assets/458ae395-05cd-4ef8-9ddc-d6baa91d2397">
After applying the chart.

## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results
- [x] I have updated/created relevant documentation

## How to test
Apply the chart but set the image.tag to `BGD-6179-handle-orphaned-driver-pods` and the image.registry to the private registry.

## Test plan and results
See PR in the watcher for more details.

| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Apply chart on cluster and see that it is configured correctly | ✅   |  |
| 2    | Integration tests  |  ✅   |   |
| 3    | Have stuck failed app CRs and observe that they get removed |  ✅   |   |