### PR TITLE
BGD-6242 Workspace stuck in starting due to missing volume

### DIFF
--- a/charts/bigdata-notebook-workspace/Chart.yaml
+++ b/charts/bigdata-notebook-workspace/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bigdata-notebook-workspace
 description: A Helm chart for the Spot Big Data Notebook Workspace
 type: application
-version: 0.0.18
+version: 0.0.19
 appVersion: 4.1.8-ofas-31799c9
 home: https://github.com/spotinst/charts
 icon: https://docs.spot.io/_media/images/spot_mark.png

--- a/charts/bigdata-notebook-workspace/templates/pvc.yaml
+++ b/charts/bigdata-notebook-workspace/templates/pvc.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.pvc.storageClassName }}
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/bigdata-notebook-workspace/values.yaml
+++ b/charts/bigdata-notebook-workspace/values.yaml
@@ -49,6 +49,7 @@ serviceAccount:
 
 pvc:
   create: true
+  storageClassName: ""
   requests:
     storage: 10Gi
 


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-6242

## Description
Add values config option to be able to specify the storage class of the PVC in the `bigdata-notebook-workspace` chart.

## Demo
Given a `values.yaml` containing
```yaml
pvc:
  storageClassName: pvc-ebs
```
A PVC with the following spec is generated:  
```yaml
spec:
  storageClassName: pvc-ebs
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
```

Without providing a `values.yaml`:
```yaml
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
```

## Checklist
- [x] I have added a Jira ticket link
- [x] I have filled in the test plan
- [x] I have executed the tests and filled in the test results
- [x] I have updated/created relevant documentation

## How to test
Helm install the chart with a valid value for `pvc.storageClassName` and check that it is successful and the PVC gets created with `spec.storageClassName` set to the provided value.

## Test plan and results
| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Manual helm install with storage class name set  | ✅ |  PV successfully created using storageClassName requested by PVC |
| 2   | Manual helm install without storage class name set  | ✅ | PVC no longer specifies a storage class  |