### PR TITLE
[charts/spark-operator/templates/rbac] add missing permissions to the cluster role

### DIFF
--- a/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
+++ b/charts/spark-operator/charts/spark-operator/templates/rbac.yaml
@@ -57,6 +57,7 @@ rules:
   - get
   - delete
   - update
+  - patch
 # required for leader-election (high-availability)
 - apiGroups:
   - "coordination.k8s.io"


### PR DESCRIPTION
Found while testing the new spark operator image https://github.com/spotinst/spark-on-k8s-operator/pull/34 
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-6109

## Description

Quartly patching => update to latest ofas sparkbase images.

## Demo

_Please add a recording/screenshot of the feature/bug fix in action_

## Checklist
- [x] I have added a Jira ticket link
- [ ] I have filled in the test plan
- [ ] I have executed the tests and filled in the test results
- [ ] I have updated/created relevant documentation

## How to test

- Run the charts on a dev DP cluster.
- Validate that the charts are installed/upgraded correctly
- Run integration tests and report any issues

## Test plan and results

_Feel free to add screenshots showing test results_

| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Run the charts on a dev DP cluster. |   |   |
| 2    | Validate that the charts are installed/upgraded correctly |   |  |
| 3    | Run integration tests and report any issues |   |  |